### PR TITLE
Implement basic license rule

### DIFF
--- a/metadata/BUILD
+++ b/metadata/BUILD
@@ -1,6 +1,21 @@
-load("//:defs.bzl", "package_metadata")
+load("//:defs.bzl", "package_metadata", "license")
 
 package_metadata(
     name = "package_metadata",
     purl = "pkg:github/bazel-contrib/supply-chain@HEAD",
+    attributes = [
+        ":license",
+    ],
+)
+
+license(
+    name = "license",
+    full_name = "Apache License 2.0",
+    spdx_short_identifier = "Apache-2.0",
+    urls = [
+        "https://github.com/bazel-contrib/supply-chain/blob/main/metadata/LICENSE",
+        "https://www.apache.org/licenses/LICENSE-2.0.html",
+        "https://spdx.org/licenses/Apache-2.0.html",
+    ],
+    text = "LICENSE",
 )

--- a/metadata/attributes/license.bzl
+++ b/metadata/attributes/license.bzl
@@ -1,0 +1,12 @@
+"""This attribute declares a license entity attached to a given target.
+The attribute is a JSON with the following format:
+- text_path: str - the path to the license file containing the text of the license
+- full_name: str? - the human readable name of the license
+- spdx_short_identifier: str? - the [SPDX short identifier](https://spdx.org/licenses/) of the license
+- urls: str[] - the URLs pointing at the definition of this license.
+The content of the license is stored as a separate file.
+"""
+
+visibility("public")
+
+KIND = "build.bazel.well-known.license"

--- a/metadata/defs.bzl
+++ b/metadata/defs.bzl
@@ -3,6 +3,7 @@
 load("//providers:package_attribute_info.bzl", _PackageAttributeInfo = "PackageAttributeInfo")
 load("//providers:package_metadata_info.bzl", _PackageMetadataInfo = "PackageMetadataInfo")
 load("//rules:package_metadata.bzl", _package_metadata = "package_metadata")
+load("//rules:license.bzl", _license = "license")
 
 visibility("public")
 
@@ -12,3 +13,4 @@ PackageMetadataInfo = _PackageMetadataInfo
 
 # Rules
 package_metadata = _package_metadata
+license = _license

--- a/metadata/rules/license.bzl
+++ b/metadata/rules/license.bzl
@@ -1,0 +1,71 @@
+"""Declares rule `license`."""
+
+load("//providers:package_attribute_info.bzl", "PackageAttributeInfo")
+load("//attributes:license.bzl", "KIND")
+
+visibility("public")
+
+def _license_impl(ctx):
+    attributes = {
+        "text_path": ctx.file.text.path
+    }
+    if len(ctx.attr.full_name) > 0:
+        attributes["full_name"] = ctx.attr.full_name
+    if len(ctx.attr.spdx_short_identifier) > 0:
+        attributes["spdx_short_identifier"] = ctx.attr.spdx_short_identifier
+    if len(ctx.attr.urls) > 0:
+        attributes["urls"] = ctx.attr.urls
+
+    attributes_file = ctx.actions.declare_file("{}.package-attribute.json".format(ctx.attr.name))
+    ctx.actions.write(
+        attributes_file,
+        json.encode(attributes)
+    )
+
+    license_content_depset = depset(direct=[ctx.file.text])
+    return [
+        DefaultInfo(
+            files = depset(
+                direct = [attributes_file],
+                transitive = [license_content_depset],
+            ),
+        ),
+        PackageAttributeInfo(
+            kind=KIND, 
+            attributes=attributes_file, 
+            files=[license_content_depset],
+        ),
+    ]
+
+license = rule(
+    implementation = _license_impl,
+    attrs = {
+        "full_name": attr.string(
+            doc = """
+The human-readable name of this license.
+""".strip(),
+        ),
+        "spdx_short_identifier": attr.string(
+            doc = """
+The [SPDX short identifier](https://spdx.org/licenses/) of this license. 
+""".strip(),
+        ),
+        "urls": attr.string_list(
+            doc = """
+The URLs pointing at the definition of this license.
+""".strip(),
+        ),
+        "text": attr.label(
+            allow_single_file = True,
+            doc = """
+The [File](https://bazel.build/rules/lib/builtins/File) containting the text of this license.
+""".strip(),
+        ),
+    },
+    provides = [
+        PackageAttributeInfo,
+    ],
+    doc = """
+Rule for declaring a license.
+""".strip(),
+)

--- a/metadata/rules/package_metadata.bzl
+++ b/metadata/rules/package_metadata.bzl
@@ -13,7 +13,7 @@ def _package_metadata_impl(ctx):
     ctx.actions.write(
         output = metadata,
         content = json.encode({
-            "attributes": {a.kind: a.metadata.path for a in attributes},
+            "attributes": {a.kind: a.attributes.path for a in attributes},
             "label": str(ctx.label),
             "purl": ctx.attr.purl,
         }),


### PR DESCRIPTION
This rule differs a bit from the one in rules license. Conditions have been dropped altogether as they are better expressed through custom attributes users can define on their own. Furthermore we add support for SPDX's short identifier which can be used to programmatically fetch information about licenses recognised by SPDX, which in turn should make the tooling more concise and reusable.

Currently we do not enforce any checks on what fields must be present, however in the future we may want to enforce a subset of fields to exist in a given license (ie: if you set `spdx_short_identifier` you may not need any other identifiers, but if you don't set it then you will at least need to provide `full_name` and `urls`).