### PR TITLE
feat: add release automation

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,0 +1,9 @@
+# Bazel Central Registry
+
+When the ruleset is released, we want it to be published to the
+Bazel Central Registry automatically:
+<https://registry.bazel.build>
+
+This folder contains configuration files to automate the publish step.
+See <https://github.com/bazel-contrib/publish-to-bcr/blob/main/templates/README.md>
+for authoritative documentation about these files.

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,6 @@
+# See https://github.com/bazel-contrib/publish-to-bcr#a-note-on-release-automation
+# for guidance about whether to uncomment this section:
+#
+# fixedReleaser:
+#   login: my_github_handle
+#   email: me@my.org

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,14 @@
+{
+  "homepage": "https://github.com/bazel-contrib/supply-chain",
+  "maintainers": [
+    {
+      "github": "Yannic"
+    },
+    {
+      "github": "TheGrizzlyDev"
+    }
+  ],
+  "repository": ["github:bazel-contrib/supply-chain"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -2,11 +2,15 @@
   "homepage": "https://github.com/bazel-contrib/supply-chain",
   "maintainers": [
     {
-      "github": "Yannic"
-    },
-    {
-      "github": "TheGrizzlyDev"
-    }
+            "email": "antonio@engflow.com",
+            "github": "TheGrizzlyDev",
+            "name": "Antonio Di Stefano"
+        },
+        {
+            "email": "yannic@engflow.com",
+            "github": "Yannic",
+            "name": "Yannic Bonenberger"
+        }
   ],
   "repository": ["github:bazel-contrib/supply-chain"],
   "versions": [],

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@package_metadata//...'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "**leave this alone**",
+  "strip_prefix": "{REPO}-{VERSION}/metadata",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,4 +18,5 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@c9d6d1893b10a8d68584a6ba52c3dd35506486d0 # 2024-12-03
     with:
+      bazel_test_command: cd metadata; bazel test //...
       release_files: supply-chain-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,6 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@c9d6d1893b10a8d68584a6ba52c3dd35506486d0 # 2024-12-03
     with:
-      bazel_test_command: cd metadata; bazel test //...
+      # TODO: change to test when there are any test targets
+      bazel_test_command: cd metadata; bazel build //...
       release_files: supply-chain-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+# Cut a release whenever a new tag appears on the repository.
+name: Release
+
+on:
+  # Developers can manually push a tag from their clone.
+  push:
+    tags:
+      # NB: this assumes a consistent tagging scheme for the repo.
+      # If/when there are multiple Bazel modules, we may find that semver requires
+      # one to remain stable while another has breaking changes. In that case we'll
+      # have to have a tagging scheme that versions modules independently.
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@c9d6d1893b10a8d68584a6ba52c3dd35506486d0 # 2024-12-03
+    with:
+      release_files: supply-chain-*.tar.gz

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+# Set by GH actions, see
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+TAG=${GITHUB_REF_NAME}
+# The prefix is chosen to match what GitHub generates for source archives
+# This guarantees that users can easily switch from a released artifact to a source archive
+# with minimal differences in their code (e.g. strip_prefix remains the same)
+PREFIX="supply-chain-${TAG:1}"
+ARCHIVE="supply-chain-$TAG.tar.gz"
+
+# NB: configuration for 'git archive' is in /.gitattributes
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
+
+cat << EOF
+## Using Bzlmod with Bazel 6 or greater
+
+1. (Bazel 6 only) Enable with \`common --enable_bzlmod\` in \`.bazelrc\`.
+2. Add to your \`MODULE.bazel\` file:
+
+\`\`\`starlark
+bazel_dep(name = "package_metadata", version = "${TAG:1}")
+\`\`\`
+
+## Using WORKSPACE
+
+Paste this snippet into your \`WORKSPACE.bazel\` file:
+
+\`\`\`starlark
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "package_metadata",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}/metadata",
+    url = "https://github.com/bazel-contrib/supply-chain/releases/download/${TAG}/${ARCHIVE}",
+)
+\`\`\`
+EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# How to Contribute
+
+## Releasing
+
+If you need control over the next release version, for example when making a release candidate for a new major,
+then: tag the repo and push the tag, for example
+
+```sh
+% git fetch
+% git tag v1.0.0-rc0 origin/main
+% git push origin v1.0.0-rc0
+```
+
+Then watch the automation run on GitHub actions which creates the release.


### PR DESCRIPTION
Design notes:

- Sequencing of the release: from experience maintaining dozens of rulesets over the years, I believe we are better off having the git tag created first. Developers determine what is the right next version. Note, there's no need to add a "release commit" to the repo - any commit may be tagged.
- I've used the naive tagging scheme `vX.X.X` with the typical `v` prefix. We could change this to `metadata` now, or could wait until there's a second module and it has to have a different versioning scheme. Personally, I'd prefer to keep this simple until we actually have the problem of different modules needing different versions - it makes it more complex for us and also for users.
- The release artifact is similar to other rulesets - it's simply the result of running `git archive` on the whole repo. The advantage is that users can switch from a release to a pre-release simply with a `git_override`. This means the `strip_prefix` has `/metadata` included. This doesn't negatively impact users even when we have more modules, as the Bazel downloader will only download `supply-chain-v1.2.3.tar.gz` a single time.

Testing:

I pushed a tag to my own fork of this project, it generated a release https://github.com/alexeagle/supply-chain/releases

1. I copied that WORKSPACE snippet (changing `bazel-contrib` to `alexeagle`) and am able to `bazel query @package_metadata//...`
2. The BCR automation created this PR https://github.com/bazelbuild/bazel-central-registry/pull/3966 which demonstrates the module release is automatically published.

Fixes #2