### PR TITLE
chore: publish provenance attestations to BCR

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,6 +1,0 @@
-# See https://github.com/bazel-contrib/publish-to-bcr#a-note-on-release-automation
-# for guidance about whether to uncomment this section:
-#
-# fixedReleaser:
-#   login: my_github_handle
-#   email: me@my.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,36 @@
+# Publish new releases to Bazel Central Registry.
+name: Publish
+
+on:
+  # Run the publish workflow after a successful release
+  # Will be triggered from the release.yaml workflow
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: true
+  # In case of problems, let release engineers retry by manually dispatching
+  # the workflow from the GitHub UI
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.4
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
+      registry_fork: bazel-contrib/bazel-central-registry
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      # Necessary to push to the BCR fork, and to open a pull request against a registry
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,22 @@ on:
       # one to remain stable while another has breaking changes. In that case we'll
       # have to have a tagging scheme that versions modules independently.
       - "v*.*.*"
-
 permissions:
+  id-token: write
+  attestations: write
   contents: write
-
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@c9d6d1893b10a8d68584a6ba52c3dd35506486d0 # 2024-12-03
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.0
     with:
       # TODO: change to test when there are any test targets
       bazel_test_command: cd metadata; bazel build //...
       release_files: supply-chain-*.tar.gz
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Switches from a GH App to a reusable workflow, which gives us better visibility into errors.

See design doc: https://github.com/bazelbuild/bazel-central-registry/discussions/2721
And modules that already publish attestations: https://github.com/search?q=repo%3Abazelbuild%2Fbazel-central-registry%20path%3Aattestations.json&type=code

It's not strictly needed for this repo, but since provenance attestations are one part of supply-chain security, it's good to include here.