### PR TITLE
[bcr] Add `@supply-chain-go` to `moduleRoots`

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -2,4 +2,5 @@
 #
 # Each module must have a directory in `github.com/bazel-contrib/supply-chain/.bcr` with the configuration to publish the module.
 moduleRoots:
+  - "lib/supplychain-go"
   - "metadata"


### PR DESCRIPTION
Otherwise, it's not picked by the workflow.