### PR TITLE
[metadata] Add util for construcing `purl`s for BCR packages

### DIFF
--- a/docs/metadata/README.md
+++ b/docs/metadata/README.md
@@ -46,11 +46,12 @@ If you are a module author and want to annotate your module, you will need to ta
     > Modules typically need only a single `package_metadata` target. However, multiple targets can be required in some cases (e.g., when some targets are licensed under a different license).
 
     ```starlark
+    load("@package_metadata//purl:purl.bzl", "purl")
     load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 
     package_metadata(
         name = "package_metadata",
-        purl = "pkg:bazel/{}@{}".format(module_name(), module_version()),
+        purl = purl.bazel(module_name(), module_version()),
         attributes = [
             # ...
         ],
@@ -127,6 +128,10 @@ If you are a module author and want to annotate your module, you will need to ta
 #### Rules
 
   - [@package_metadata//rules:package_metadata.bzl](./rules/package_metadata.md)
+
+#### Utils
+
+  - [@package_metadata//purl:purl.bzl](./purl/purl.md)
 
 
 ### Licenses

--- a/docs/metadata/defs.md
+++ b/docs/metadata/defs.md
@@ -70,3 +70,49 @@ package_metadata(*, <a href="#package_metadata-name">name</a>, <a href="#package
 | <a id="package_metadata-visibility"></a>visibility |  <p align="center"> - </p>   |  `None` |
 
 
+<a id="purl.bazel"></a>
+
+## purl.bazel
+
+<pre>
+load("@package_metadata//:defs.bzl", "purl")
+
+purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>)
+</pre>
+
+Defines a `purl` for a Bazel module.
+
+This is typically used to construct `purl` for `package_metadata` targets in
+Bazel modules.
+
+This is **NOT** supported in `WORKSPACE` mode.
+
+Example:
+
+```starlark
+load("@package_metadata//purl:purl.bzl", "purl")
+
+package_metadata(
+    name = "package_metadata",
+    purl = purl.bazel(module_name(), module_version()),
+    attributes = [
+        # ...
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="purl.bazel-name"></a>name |  The name of the Bazel module. Typically [module_name()](https://bazel.build/rules/lib/globals/build#module_name).   |  none |
+| <a id="purl.bazel-version"></a>version |  The version of the Bazel module. Typically [module_version()](https://bazel.build/rules/lib/globals/build#module_version). May be empty or `None`.   |  none |
+
+**RETURNS**
+
+The `purl` for the Bazel module (e.g. `pkg:bazel/foo` or
+  `pkg:bazel/bar@1.2.3`).
+
+

--- a/docs/metadata/purl/BUILD
+++ b/docs/metadata/purl/BUILD
@@ -1,0 +1,17 @@
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
+
+stardoc(
+    name = "purl",
+    out = "purl.generated.md",
+    input = "@package_metadata//purl:purl.bzl",
+    deps = [
+        "@package_metadata//purl:srcs",
+    ],
+)
+
+diff_test(
+    name = "purl_test",
+    file1 = ":purl",
+    file2 = "purl.md",
+)

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -1,0 +1,50 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Module defining urils for [purl](https://github.com/package-url/purl-spec)s.
+
+<a id="purl.bazel"></a>
+
+## purl.bazel
+
+<pre>
+load("@package_metadata//purl:purl.bzl", "purl")
+
+purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>)
+</pre>
+
+Defines a `purl` for a Bazel module.
+
+This is typically used to construct `purl` for `package_metadata` targets in
+Bazel modules.
+
+This is **NOT** supported in `WORKSPACE` mode.
+
+Example:
+
+```starlark
+load("@package_metadata//purl:purl.bzl", "purl")
+
+package_metadata(
+    name = "package_metadata",
+    purl = purl.bazel(module_name(), module_version()),
+    attributes = [
+        # ...
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="purl.bazel-name"></a>name |  The name of the Bazel module. Typically [module_name()](https://bazel.build/rules/lib/globals/build#module_name).   |  none |
+| <a id="purl.bazel-version"></a>version |  The version of the Bazel module. Typically [module_version()](https://bazel.build/rules/lib/globals/build#module_version). May be empty or `None`.   |  none |
+
+**RETURNS**
+
+The `purl` for the Bazel module (e.g. `pkg:bazel/foo` or
+  `pkg:bazel/bar@1.2.3`).
+
+

--- a/metadata/BUILD
+++ b/metadata/BUILD
@@ -1,4 +1,5 @@
 load("//licenses/rules:license.bzl", "license")
+load("//purl:purl.bzl", "purl")
 load("//rules:package_metadata.bzl", "package_metadata")
 
 exports_files(
@@ -14,6 +15,7 @@ filegroup(
         "defs.bzl",
     ] + [
         "//providers:srcs",
+        "//purl:srcs",
         "//rules:srcs",
     ],
     visibility = ["//visibility:public"],
@@ -24,7 +26,7 @@ package_metadata(
     attributes = [
         ":license",
     ],
-    purl = "pkg:bazel/{}@{}".format(
+    purl = purl.bazel(
         module_name(),
         module_version(),
     ),

--- a/metadata/MODULE.bazel
+++ b/metadata/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "package_metadata",
-    version = "HEAD",  # Automatically updated by release pipeline.
+    version = "",  # Automatically updated by release pipeline.
 )
 
 # This is a fundamental module that's depended on by virtually every bazel

--- a/metadata/defs.bzl
+++ b/metadata/defs.bzl
@@ -2,6 +2,7 @@
 
 load("//providers:package_attribute_info.bzl", _PackageAttributeInfo = "PackageAttributeInfo")
 load("//providers:package_metadata_info.bzl", _PackageMetadataInfo = "PackageMetadataInfo")
+load("//purl:purl.bzl", _purl = "purl")
 load("//rules:package_metadata.bzl", _package_metadata = "package_metadata")
 
 visibility("public")
@@ -12,3 +13,6 @@ PackageMetadataInfo = _PackageMetadataInfo
 
 # Rules
 package_metadata = _package_metadata
+
+# Utils
+purl = _purl

--- a/metadata/purl/BUILD
+++ b/metadata/purl/BUILD
@@ -1,0 +1,14 @@
+exports_files(
+    [
+        "purl.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = [
+        "purl.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -1,0 +1,46 @@
+"""Module defining urils for [purl](https://github.com/package-url/purl-spec)s."""
+
+visibility("public")
+
+def _bazel(name, version):
+    """Defines a `purl` for a Bazel module.
+
+    This is typically used to construct `purl` for `package_metadata` targets in
+    Bazel modules.
+
+    This is **NOT** supported in `WORKSPACE` mode.
+
+    Example:
+
+    ```starlark
+    load("@package_metadata//purl:purl.bzl", "purl")
+
+    package_metadata(
+        name = "package_metadata",
+        purl = purl.bazel(module_name(), module_version()),
+        attributes = [
+            # ...
+        ],
+        visibility = ["//visibility:public"],
+    )
+
+    Args:
+        name (str): The name of the Bazel module. Typically
+                    [module_name()](https://bazel.build/rules/lib/globals/build#module_name).
+        version (str): The version of the Bazel module. Typically
+                       [module_version()](https://bazel.build/rules/lib/globals/build#module_version).
+                       May be empty or `None`.
+
+    Returns:
+        The `purl` for the Bazel module (e.g. `pkg:bazel/foo` or
+        `pkg:bazel/bar@1.2.3`).
+    """
+
+    if not version:
+        return "pkg:bazel/{}".format(name)
+
+    return "pkg:bazel/{}@{}".format(name, version)
+
+purl = struct(
+    bazel = _bazel,
+)


### PR DESCRIPTION
Instead of having to write `purl = "pkg:bazel/{}@{}".format(module_name(), module_version()) if module_version() else "pkg:bazel/{}".format(module_name())` everywhere to construct a `purl`, users can now write `purl = purl.bazel(module_name(), module_version())` and it'll automatically do the right thing.