### PR TITLE
[lib] go: fix path of module

### DIFF
--- a/lib/supplychain-go/go.mod
+++ b/lib/supplychain-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/bazel-contrib/supply-chain/lib/supply-chain-go
+module github.com/bazel-contrib/supply-chain/lib/supplychain-go
 
 go 1.24.2
 


### PR DESCRIPTION
The path must match the file-system path.