### PR TITLE
[release] Don't create draft PRs in BCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,5 +89,6 @@ jobs:
     with:
       tag_name: "v${{ inputs.version }}"
       registry_fork: "bazel-contrib/bazel-central-registry"
+      draft: false
     secrets:
       publish_token: "${{ secrets.BCR_PUBLISH_TOKEN }}"


### PR DESCRIPTION
I'm not sure why the default is to create draft PRs, but it is :(

https://github.com/bazelbuild/bazel-central-registry/pull/5305