### PR TITLE
Pull list of PacakgeAttributeInfo from children into PackageMetadataInfo.

### DIFF
--- a/metadata/providers/package_metadata_info.bzl
+++ b/metadata/providers/package_metadata_info.bzl
@@ -2,8 +2,9 @@
 
 visibility("public")
 
-def _init(metadata, files = []):
+def _init(metadata, files = [], attributes = []):
     return {
+        "attributes": attributes,
         "files": depset(
             direct = [
                 metadata,
@@ -20,6 +21,10 @@ Provider for declaring metadata about a Bazel package.
 > **Fields in this provider are not covered by the stability gurantee.**
 """.strip(),
     fields = {
+        "attributes": """
+A [depset](https://bazel.build/rules/lib/builtins/depset) of
+`PackageAttributeInfo` providers.
+""".strip(),
         "files": """
 A [depset](https://bazel.build/rules/lib/builtins/depset) of
 [File](https://bazel.build/rules/lib/builtins/File)s with metadata about the
@@ -28,10 +33,6 @@ package, including transitive files from all attributes of the package.
         "metadata": """
 The [File](https://bazel.build/rules/lib/builtins/File) containing metadata
 about the package.
-""".strip(),
-        "attributes": """
-A [depset](https://bazel.build/rules/lib/builtins/depset) of
-`PackageAttributeInfo` providers.
 """.strip(),
     },
     init = _init,

--- a/metadata/providers/package_metadata_info.bzl
+++ b/metadata/providers/package_metadata_info.bzl
@@ -29,6 +29,10 @@ package, including transitive files from all attributes of the package.
 The [File](https://bazel.build/rules/lib/builtins/File) containing metadata
 about the package.
 """.strip(),
+        "attributes": """
+A [depset](https://bazel.build/rules/lib/builtins/depset) of
+`PackageAttributeInfo` providers.
+""".strip(),
     },
     init = _init,
 )

--- a/metadata/rules/package_metadata.bzl
+++ b/metadata/rules/package_metadata.bzl
@@ -9,7 +9,6 @@ def _package_metadata_impl(ctx):
     attributes = [a[PackageAttributeInfo] for a in ctx.attr.attributes]
 
     metadata = ctx.actions.declare_file("{}.package-metadata.json".format(ctx.attr.name))
-
     ctx.actions.write(
         output = metadata,
         content = json.encode({
@@ -28,8 +27,9 @@ def _package_metadata_impl(ctx):
             ),
         ),
         PackageMetadataInfo(
-            metadata = metadata,
+            attributes = attributes,
             files = [a.files for a in attributes],
+            metadata = metadata,
         ),
     ]
 


### PR DESCRIPTION
Pull list of PacakgeAttributeInfo from children into PackageMetadataInfo.

This allows an aspect descending from a target to see the PackageAttributeInfo instances for a `package_metadata` instance when it is attached to that target via the common attribute `package_metadata`.

 Review question: Should we drop the `files` field from PMI. It is no redundant w.r.t. the `attributes` field.