### PR TITLE
[metadata] Add `PackageMetadataCollectionInfo`

### DIFF
--- a/docs/metadata/defs.md
+++ b/docs/metadata/defs.md
@@ -25,6 +25,37 @@ Provider for declaring metadata about a Bazel package.
 | <a id="PackageAttributeInfo-files"></a>files | A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s containing information about this attribute. | `[]` |
 
 
+<a id="PackageMetadataCollectionInfo"></a>
+
+## PackageMetadataCollectionInfo
+
+<pre>
+load("@package_metadata//:defs.bzl", "PackageMetadataCollectionInfo")
+
+PackageMetadataCollectionInfo(<a href="#PackageMetadataCollectionInfo-_init-dependencies">dependencies</a>, <a href="#PackageMetadataCollectionInfo-_init-tools">tools</a>, <a href="#PackageMetadataCollectionInfo-_init-deps">deps</a>)
+</pre>
+
+Provides a collection of `PackageMetadataInfo`s transitively used by target.
+
+> **Fields in this provider are not covered by the stability gurantee.**
+
+**CONSTRUCTOR PARAMETERS**
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="PackageMetadataCollectionInfo-_init-dependencies"></a>dependencies | A [depset](https://bazel.build/rules/lib/builtins/depset) of `PackageMetadataInfo`s that are dependencies of the targets.<br><br>This only includes dependencies that are used at runtime (i.e., from `cfg = "target"`). For dependencies that are needed at compile time (e.g., compilers, linters, ...), see `tools`. | `[]` |
+| <a id="PackageMetadataCollectionInfo-_init-tools"></a>tools | A [depset](https://bazel.build/rules/lib/builtins/depset) of `PackageMetadataInfo`s that are are needed to build the target.<br><br>For dependencies that are needed at runtime time see `dependencies`. | `[]` |
+| <a id="PackageMetadataCollectionInfo-_init-deps"></a>deps | <p align="center">-</p> | `[]` |
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PackageMetadataCollectionInfo-dependencies"></a>dependencies |  A [depset](https://bazel.build/rules/lib/builtins/depset) of `PackageMetadataInfo`s that are dependencies of the targets.<br><br>This only includes dependencies that are used at runtime (i.e., from `cfg = "target"`). For dependencies that are needed at compile time (e.g., compilers, linters, ...), see `tools`.    |
+| <a id="PackageMetadataCollectionInfo-files"></a>files |  A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s referenced by `PackageMetadataInfo` providers in this collection.    |
+| <a id="PackageMetadataCollectionInfo-tools"></a>tools |  A [depset](https://bazel.build/rules/lib/builtins/depset) of `PackageMetadataInfo`s that are are needed to build the target.<br><br>For dependencies that are needed at runtime time see `dependencies`.    |
+
+
 <a id="PackageMetadataInfo"></a>
 
 ## PackageMetadataInfo

--- a/docs/metadata/providers/BUILD
+++ b/docs/metadata/providers/BUILD
@@ -17,6 +17,21 @@ diff_test(
 )
 
 stardoc(
+    name = "package_metadata_collection_info",
+    out = "package_metadata_collection_info.generated.md",
+    input = "@package_metadata//providers:package_metadata_collection_info.bzl",
+    deps = [
+        "@package_metadata//providers:srcs",
+    ],
+)
+
+diff_test(
+    name = "package_metadata_collection_info_test",
+    file1 = ":package_metadata_collection_info",
+    file2 = "package_metadata_collection_info.md",
+)
+
+stardoc(
     name = "package_metadata_info",
     out = "package_metadata_info.generated.md",
     input = "@package_metadata//providers:package_metadata_info.bzl",

--- a/docs/metadata/providers/package_metadata_collection_info.md
+++ b/docs/metadata/providers/package_metadata_collection_info.md
@@ -1,0 +1,35 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Declares provider `PackageMetadataCollectionInfo`.
+
+<a id="PackageMetadataCollectionInfo"></a>
+
+## PackageMetadataCollectionInfo
+
+<pre>
+load("@package_metadata//providers:package_metadata_collection_info.bzl", "PackageMetadataCollectionInfo")
+
+PackageMetadataCollectionInfo(<a href="#PackageMetadataCollectionInfo-_init-dependencies">dependencies</a>, <a href="#PackageMetadataCollectionInfo-_init-tools">tools</a>, <a href="#PackageMetadataCollectionInfo-_init-deps">deps</a>)
+</pre>
+
+Provides a collection of `PackageMetadataInfo`s transitively used by target.
+
+> **Fields in this provider are not covered by the stability gurantee.**
+
+**CONSTRUCTOR PARAMETERS**
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="PackageMetadataCollectionInfo-_init-dependencies"></a>dependencies | A [depset](https://bazel.build/rules/lib/builtins/depset) of `PackageMetadataInfo`s that are dependencies of the targets.<br><br>This only includes dependencies that are used at runtime (i.e., from `cfg = "target"`). For dependencies that are needed at compile time (e.g., compilers, linters, ...), see `tools`. | `[]` |
+| <a id="PackageMetadataCollectionInfo-_init-tools"></a>tools | A [depset](https://bazel.build/rules/lib/builtins/depset) of `PackageMetadataInfo`s that are are needed to build the target.<br><br>For dependencies that are needed at runtime time see `dependencies`. | `[]` |
+| <a id="PackageMetadataCollectionInfo-_init-deps"></a>deps | <p align="center">-</p> | `[]` |
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PackageMetadataCollectionInfo-dependencies"></a>dependencies |  A [depset](https://bazel.build/rules/lib/builtins/depset) of `PackageMetadataInfo`s that are dependencies of the targets.<br><br>This only includes dependencies that are used at runtime (i.e., from `cfg = "target"`). For dependencies that are needed at compile time (e.g., compilers, linters, ...), see `tools`.    |
+| <a id="PackageMetadataCollectionInfo-files"></a>files |  A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s referenced by `PackageMetadataInfo` providers in this collection.    |
+| <a id="PackageMetadataCollectionInfo-tools"></a>tools |  A [depset](https://bazel.build/rules/lib/builtins/depset) of `PackageMetadataInfo`s that are are needed to build the target.<br><br>For dependencies that are needed at runtime time see `dependencies`.    |
+
+

--- a/metadata/defs.bzl
+++ b/metadata/defs.bzl
@@ -1,6 +1,7 @@
 """Public API of `@package_metadata`."""
 
 load("//providers:package_attribute_info.bzl", _PackageAttributeInfo = "PackageAttributeInfo")
+load("//providers:package_metadata_collection_info.bzl", _PackageMetadataCollectionInfo = "PackageMetadataCollectionInfo")
 load("//providers:package_metadata_info.bzl", _PackageMetadataInfo = "PackageMetadataInfo")
 load("//purl:purl.bzl", _purl = "purl")
 load("//rules:package_metadata.bzl", _package_metadata = "package_metadata")
@@ -9,6 +10,7 @@ visibility("public")
 
 # Providers.
 PackageAttributeInfo = _PackageAttributeInfo
+PackageMetadataCollectionInfo = _PackageMetadataCollectionInfo
 PackageMetadataInfo = _PackageMetadataInfo
 
 # Rules

--- a/metadata/providers/BUILD
+++ b/metadata/providers/BUILD
@@ -1,6 +1,7 @@
 exports_files(
     [
         "package_attribute_info.bzl",
+        "package_metadata_collection_info.bzl",
         "package_metadata_info.bzl",
     ],
     visibility = ["//visibility:public"],
@@ -10,6 +11,7 @@ filegroup(
     name = "srcs",
     srcs = [
         "package_attribute_info.bzl",
+        "package_metadata_collection_info.bzl",
         "package_metadata_info.bzl",
     ],
     visibility = ["//visibility:public"],

--- a/metadata/providers/package_metadata_collection_info.bzl
+++ b/metadata/providers/package_metadata_collection_info.bzl
@@ -1,0 +1,48 @@
+"""Declares provider `PackageMetadataCollectionInfo`."""
+
+visibility("public")
+
+def _init(dependencies = [], tools = [], deps = []):
+    return {
+        "dependencies": depset(
+            direct = dependencies,
+            transitive = [p.dependencies for p in deps],
+        ),
+        "files": depset(
+            transitive = [p.files for p in dependencies] + [p.files for p in tools] + [p.files for p in deps],
+        ),
+        "tools": depset(
+            direct = tools,
+            transitive = [p.tools for p in deps],
+        ),
+    }
+
+PackageMetadataCollectionInfo, _create = provider(
+    doc = """
+Provides a collection of `PackageMetadataInfo`s transitively used by target.
+
+> **Fields in this provider are not covered by the stability gurantee.**
+""".strip(),
+    fields = {
+        "dependencies": """
+A [depset](https://bazel.build/rules/lib/builtins/depset) of
+`PackageMetadataInfo`s that are dependencies of the targets.
+
+This only includes dependencies that are used at runtime (i.e., from
+`cfg = "target"`). For dependencies that are needed at compile time (e.g.,
+compilers, linters, ...), see `tools`.
+""".strip(),
+        "files": """
+A [depset](https://bazel.build/rules/lib/builtins/depset) of
+[File](https://bazel.build/rules/lib/builtins/File)s referenced by
+`PackageMetadataInfo` providers in this collection.
+""".strip(),
+        "tools": """
+A [depset](https://bazel.build/rules/lib/builtins/depset) of
+`PackageMetadataInfo`s that are are needed to build the target.
+
+For dependencies that are needed at runtime time see `dependencies`.
+""".strip(),
+    },
+    init = _init,
+)


### PR DESCRIPTION
This PR adds a new provider `PackageMetadataCollectionInfo`, which can be used (by an aspect) to collect all `PackageMetadataInfo` providers from the transitive closure of a target.

The provider splits dependencies into two categories:
  - runtime dependencies that are shipped in the final binary
  - tool dependencies, which are only needed at build time (e.g., compilers, linkers, linters, ...).

For simplicity, runtime dependencies are simply called `dependencies` in the provider as "runtime dependencies" is what most people think about when thinking about dependencies.