### PR TITLE
Bugfix: gather 'applicable_licenses' when 'package_metadata' is missing

### DIFF
--- a/tools/gather_metadata/core.bzl
+++ b/tools/gather_metadata/core.bzl
@@ -136,6 +136,8 @@ def gather_metadata_info_common(
     else:
         if hasattr(ctx.rule.attr, "package_metadata"):
             package_metadata = ctx.rule.attr.package_metadata
+        elif hasattr(ctx.rule.attr, "applicable_licenses"):
+            package_metadata = ctx.rule.attr.applicable_licenses
         else:
             package_metadata = []
         for metadata_dependency in package_metadata:


### PR DESCRIPTION
With Bazel < 8, 'applicable_licenses' isn't just an alias for 'package_metadata', but rather its own attribute. As such our optimistic gathering of package_metadata won't work there and we need a fallback case for 'applicable_licenses'