### PR TITLE
Add kind and purl to PackageMetadataInfo

### DIFF
--- a/docs/metadata/defs.md
+++ b/docs/metadata/defs.md
@@ -32,19 +32,29 @@ Provider for declaring metadata about a Bazel package.
 <pre>
 load("@package_metadata//:defs.bzl", "PackageMetadataInfo")
 
-PackageMetadataInfo(<a href="#PackageMetadataInfo-metadata">metadata</a>, <a href="#PackageMetadataInfo-files">files</a>)
+PackageMetadataInfo(<a href="#PackageMetadataInfo-_init-metadata">metadata</a>, <a href="#PackageMetadataInfo-_init-purl">purl</a>, <a href="#PackageMetadataInfo-_init-files">files</a>)
 </pre>
 
 Provider for declaring metadata about a Bazel package.
 
 > **Fields in this provider are not covered by the stability gurantee.**
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="PackageMetadataInfo-metadata"></a>metadata | The [File](https://bazel.build/rules/lib/builtins/File) containing metadata about the package. | none |
-| <a id="PackageMetadataInfo-files"></a>files | A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s with metadata about the package, including transitive files from all attributes of the package. | `[]` |
+| <a id="PackageMetadataInfo-_init-metadata"></a>metadata | The [File](https://bazel.build/rules/lib/builtins/File) containing metadata about the package. | none |
+| <a id="PackageMetadataInfo-_init-purl"></a>purl | PURL | none |
+| <a id="PackageMetadataInfo-_init-files"></a>files | A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s with metadata about the package, including transitive files from all attributes of the package. | `[]` |
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PackageMetadataInfo-kind"></a>kind |  Type descriminator    |
+| <a id="PackageMetadataInfo-files"></a>files |  A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s with metadata about the package, including transitive files from all attributes of the package.    |
+| <a id="PackageMetadataInfo-metadata"></a>metadata |  The [File](https://bazel.build/rules/lib/builtins/File) containing metadata about the package.    |
+| <a id="PackageMetadataInfo-purl"></a>purl |  PURL    |
 
 
 <a id="package_metadata"></a>

--- a/docs/metadata/providers/package_metadata_info.md
+++ b/docs/metadata/providers/package_metadata_info.md
@@ -9,18 +9,28 @@ Declares provider `PackageMetadataInfo`.
 <pre>
 load("@package_metadata//providers:package_metadata_info.bzl", "PackageMetadataInfo")
 
-PackageMetadataInfo(<a href="#PackageMetadataInfo-metadata">metadata</a>, <a href="#PackageMetadataInfo-files">files</a>)
+PackageMetadataInfo(<a href="#PackageMetadataInfo-_init-metadata">metadata</a>, <a href="#PackageMetadataInfo-_init-purl">purl</a>, <a href="#PackageMetadataInfo-_init-files">files</a>)
 </pre>
 
 Provider for declaring metadata about a Bazel package.
 
 > **Fields in this provider are not covered by the stability gurantee.**
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="PackageMetadataInfo-metadata"></a>metadata | The [File](https://bazel.build/rules/lib/builtins/File) containing metadata about the package. | none |
-| <a id="PackageMetadataInfo-files"></a>files | A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s with metadata about the package, including transitive files from all attributes of the package. | `[]` |
+| <a id="PackageMetadataInfo-_init-metadata"></a>metadata | The [File](https://bazel.build/rules/lib/builtins/File) containing metadata about the package. | none |
+| <a id="PackageMetadataInfo-_init-purl"></a>purl | PURL | none |
+| <a id="PackageMetadataInfo-_init-files"></a>files | A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s with metadata about the package, including transitive files from all attributes of the package. | `[]` |
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PackageMetadataInfo-kind"></a>kind |  Type descriminator    |
+| <a id="PackageMetadataInfo-files"></a>files |  A [depset](https://bazel.build/rules/lib/builtins/depset) of [File](https://bazel.build/rules/lib/builtins/File)s with metadata about the package, including transitive files from all attributes of the package.    |
+| <a id="PackageMetadataInfo-metadata"></a>metadata |  The [File](https://bazel.build/rules/lib/builtins/File) containing metadata about the package.    |
+| <a id="PackageMetadataInfo-purl"></a>purl |  PURL    |
 
 

--- a/metadata/providers/package_metadata_info.bzl
+++ b/metadata/providers/package_metadata_info.bzl
@@ -2,8 +2,9 @@
 
 visibility("public")
 
-def _init(metadata, files = []):
+def _init(metadata, purl, files = []):
     return {
+        "kind": "build.bazel.attribute.package_metadata",
         "files": depset(
             direct = [
                 metadata,
@@ -11,6 +12,7 @@ def _init(metadata, files = []):
             transitive = files,
         ),
         "metadata": metadata,
+        "purl": purl,
     }
 
 PackageMetadataInfo, _create = provider(
@@ -20,6 +22,7 @@ Provider for declaring metadata about a Bazel package.
 > **Fields in this provider are not covered by the stability gurantee.**
 """.strip(),
     fields = {
+        "kind": """Type descriminator""",
         "files": """
 A [depset](https://bazel.build/rules/lib/builtins/depset) of
 [File](https://bazel.build/rules/lib/builtins/File)s with metadata about the
@@ -29,6 +32,7 @@ package, including transitive files from all attributes of the package.
 The [File](https://bazel.build/rules/lib/builtins/File) containing metadata
 about the package.
 """.strip(),
+        "purl": """PURL""",
     },
     init = _init,
 )

--- a/metadata/rules/package_metadata.bzl
+++ b/metadata/rules/package_metadata.bzl
@@ -29,6 +29,7 @@ def _package_metadata_impl(ctx):
         ),
         PackageMetadataInfo(
             metadata = metadata,
+            purl = ctx.attr.purl,
             files = [a.files for a in attributes],
         ),
     ]


### PR DESCRIPTION
kind helps when dispatching on gathered metadata when mixing out stuff with company private metadata. It is a valid distinguisher to know to pass that to sbom generation.

Having the purl in the provide helps with debugging and demos, and simply being able to produce useful output during analysis time.