### PR TITLE
export licenses:srcs

### DIFF
--- a/metadata/BUILD
+++ b/metadata/BUILD
@@ -14,6 +14,7 @@ filegroup(
     srcs = [
         "defs.bzl",
     ] + [
+        "//licenses:srcs",
         "//providers:srcs",
         "//purl:srcs",
         "//rules:srcs",


### PR DESCRIPTION
We need to export this so that when we add it to rules_license the CI tests there still pass.  Sigh.