### PR TITLE
Set explicit version on tools/MODULE.bzel

### DIFF
--- a/tools/MODULE.bazel
+++ b/tools/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "supply_chain_tools",
-    version = "",  # Automatically updated by release pipeline.
+    version = "0.0.1",
 )
 
 # Do not update to newer versions until you need a specific new feature.


### PR DESCRIPTION
Set explicit version because we have no pipeline to automatically set it.

And we need a version in the BCR, and the MODULE in the BCR must match this one. Sigh.