### PR TITLE
lib/supplychain-go: Fix package_metadata version

### DIFF
--- a/lib/supplychain-go/MODULE.bazel
+++ b/lib/supplychain-go/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 
 bazel_dep(
     name = "package_metadata",
-    version = "HEAD",  # Automatically updated by release pipeline.
+    version = "0.0.6",
 )
 bazel_dep(
     name = "rules_go",


### PR DESCRIPTION
When using a local override of supply-chain-go, without a local override of package_metadata, supply-chain-go's reference to package_metadata must have a valid version. And this makes sense. If supply-chain-go can work with an older package_metadata, it should.