### PR TITLE
Remove comma that breaks release scripting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,9 @@ jobs:
 
           # 2. Update `MODULE.bazel` and commit.
           #
-          # TODO(yannic): Read directories from `//.bcr:config.yaml`.
-          bzlmod_names=("supply-chain-docs" "package_metadata" "package_metadata_extensions" "supply-chain-go")
-          bzlmod_directories=("docs" "lib/supplychain-go" "metadata", "metadata-extensions")
+          # TODO(yannic): Allow for all repos to go at different cadences.
+          bzlmod_names=("package_metadata" "package_metadata_extensions" "supply-chain-go" "supply-chain-docs")
+          bzlmod_directories=("metadata"  "metadata-extensions" "lib/supplychain-go" "docs")
 
           for bzlmod_directory in "${bzlmod_directories[@]}"; do
             for bzlmod_name in "${bzlmod_names[@]}"; do


### PR DESCRIPTION
The whole thing needs to be burned down and rebuilt to allow each library to go at different cadence, but this will do for today.