### PR TITLE
Disable renovate.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "enabled": false
 }


### PR DESCRIPTION
Fixes #81

We do not want people to have to update their tools when our things change, unless absolutely needed.