### PR TITLE
Add `registry` parameter to `purl.bazel()`

### DIFF
--- a/docs/metadata/defs.md
+++ b/docs/metadata/defs.md
@@ -121,7 +121,7 @@ package_metadata(*, <a href="#package_metadata-name">name</a>, <a href="#package
 <pre>
 load("@package_metadata//:defs.bzl", "purl")
 
-purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>)
+purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>, <a href="#purl.bazel-registry">registry</a>)
 </pre>
 
 Defines a `purl` for a Bazel module.
@@ -154,6 +154,7 @@ package_metadata(
 | :------------- | :------------- | :------------- |
 | <a id="purl.bazel-name"></a>name |  The name of the Bazel module. Typically [module_name()](https://bazel.build/rules/lib/globals/build#module_name).   |  none |
 | <a id="purl.bazel-version"></a>version |  The version of the Bazel module. Typically [module_version()](https://bazel.build/rules/lib/globals/build#module_version). May be empty or `None`.   |  none |
+| <a id="purl.bazel-registry"></a>registry |  The URL of the registry that hosts the Bazel module. Defaults to https://bcr.bazel.build.   |  `"https://bcr.bazel.build"` |
 
 **RETURNS**
 

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -9,7 +9,7 @@ Module defining urils for [purl](https://github.com/package-url/purl-spec)s.
 <pre>
 load("@package_metadata//purl:purl.bzl", "purl")
 
-purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>)
+purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>, <a href="#purl.bazel-registry">registry</a>)
 </pre>
 
 Defines a `purl` for a Bazel module.
@@ -42,6 +42,7 @@ package_metadata(
 | :------------- | :------------- | :------------- |
 | <a id="purl.bazel-name"></a>name |  The name of the Bazel module. Typically [module_name()](https://bazel.build/rules/lib/globals/build#module_name).   |  none |
 | <a id="purl.bazel-version"></a>version |  The version of the Bazel module. Typically [module_version()](https://bazel.build/rules/lib/globals/build#module_version). May be empty or `None`.   |  none |
+| <a id="purl.bazel-registry"></a>registry |  The URL of the registry that hosts the Bazel module. Defaults to https://bcr.bazel.build.   |  `"https://bcr.bazel.build"` |
 
 **RETURNS**
 

--- a/metadata/purl/BUILD
+++ b/metadata/purl/BUILD
@@ -1,5 +1,5 @@
 load("//purl:percent_encoding_test.bzl", "percent_encoding_test")
-load("//purl/private:tables_test.bzl", "test_cases")
+load("//purl:private/tables_test.bzl", "test_cases")
 
 exports_files(
     [
@@ -11,7 +11,10 @@ exports_files(
 filegroup(
     name = "srcs",
     srcs = [
+        "percent_encoding.bzl",
         "purl.bzl",
+        "private/tables.bzl",
+        "string.bzl",
     ],
     visibility = ["//visibility:public"],
 )

--- a/metadata/purl/percent_encoding.bzl
+++ b/metadata/purl/percent_encoding.bzl
@@ -4,7 +4,7 @@ Spec: https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#
 """
 
 load("//purl:string.bzl", "string")
-load("//purl/private:tables.bzl", "encode_byte")
+load(":private/tables.bzl", "encode_byte")
 
 visibility([
     "//purl/...",

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -2,7 +2,9 @@
 
 visibility("public")
 
-def _bazel(name, version):
+_DEFAULT_REGISTRY = "https://bcr.bazel.build"
+
+def _bazel(name, version, registry = _DEFAULT_REGISTRY):
     """Defines a `purl` for a Bazel module.
 
     This is typically used to construct `purl` for `package_metadata` targets in
@@ -31,16 +33,18 @@ def _bazel(name, version):
         version (str): The version of the Bazel module. Typically
                        [module_version()](https://bazel.build/rules/lib/globals/build#module_version).
                        May be empty or `None`.
+        registry (str): The URL of the registry that hosts the Bazel module. Defaults to
+                        https://bcr.bazel.build.
 
     Returns:
         The `purl` for the Bazel module (e.g. `pkg:bazel/foo` or
         `pkg:bazel/bar@1.2.3`).
     """
 
-    if not version:
-        return "pkg:bazel/{}".format(name)
-
-    return "pkg:bazel/{}@{}".format(name, version)
+    version_part = "@{}".format(version) if version else ""
+    normalized_registry = registry.rstrip("/")
+    registry_part = "?repository_url={}".format(normalized_registry) if normalized_registry != _DEFAULT_REGISTRY else ""
+    return "pkg:bazel/{}{}{}".format(name, version_part, registry_part)
 
 purl = struct(
     bazel = _bazel,

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -1,5 +1,7 @@
 """Module defining urils for [purl](https://github.com/package-url/purl-spec)s."""
 
+load(":percent_encoding.bzl", "percent_encode")
+
 visibility("public")
 
 _DEFAULT_REGISTRY = "https://bcr.bazel.build"
@@ -43,7 +45,10 @@ def _bazel(name, version, registry = _DEFAULT_REGISTRY):
 
     version_part = "@{}".format(version) if version else ""
     normalized_registry = registry.rstrip("/")
-    registry_part = "?repository_url={}".format(normalized_registry) if normalized_registry != _DEFAULT_REGISTRY else ""
+    if normalized_registry != _DEFAULT_REGISTRY:
+        registry_part = "?repository_url={}".format(percent_encode(normalized_registry))
+    else:
+        registry_part = ""
     return "pkg:bazel/{}{}{}".format(name, version_part, registry_part)
 
 purl = struct(


### PR DESCRIPTION
This can be populated by Bazel modules and results in a `repository_url` qualifier if the registry isn't the BCR.