### PR TITLE
Check presence of metadata field before using it

### DIFF
--- a/tools/sbom/sbom.bzl
+++ b/tools/sbom/sbom.bzl
@@ -14,10 +14,11 @@ def _sbom_impl(ctx):
     config = { "deps": [] }
     for transitive_metadata in transitive_metadata_info.trans.to_list():
         for m in transitive_metadata.metadata.to_list():
-            config["deps"].append({
-                "metadata": m.metadata.path
-            })
-            transitive_inputs.append(m.files)
+            if hasattr(m, "metadata"):
+                config["deps"].append({
+                    "metadata": m.metadata.path
+                })
+                transitive_inputs.append(m.files)
 
     sbom_gen_config = ctx.actions.declare_file("{name}.sbom.config.json".format(name=ctx.attr.name))
     ctx.actions.write(sbom_gen_config, json.encode(config))


### PR DESCRIPTION
Prevents a failure in the case where we run an sbom rule on a target which includes nothing with package_metadata.
Tested in the github.com/datadog-agent (which is where I noticed the bug)