### PR TITLE
Add a workflow to release the tools

### DIFF
--- a/.github/workflows/release_metadata.yml
+++ b/.github/workflows/release_metadata.yml
@@ -1,4 +1,4 @@
-name: "Create release"
+name: "Create release of package_metadata"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,17 +2,36 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Passed as argument when invoking the script.
+# Passed as argument when invoking the script. E.g supply_chain_tools-1.2.3
 TAG="${1}"
 
-# The prefix is chosen to match what GitHub generates for source archives
-# This guarantees that users can easily switch from a released artifact to a source archive
-# with minimal differences in their code (e.g. strip_prefix remains the same)
-PREFIX="supply-chain-${TAG:1}"
-ARCHIVE="supply-chain-$TAG.tar.gz"
+case "${TAG}" in 
+  v[0-9]* )
+    # The prefix is chosen to match what GitHub generates for source archives
+    # This guarantees that users can easily switch from a released artifact to a source archive
+    # with minimal differences in their code (e.g. strip_prefix remains the same)
+    VERSION="${TAG:1}"
+    PREFIX="supply-chain-${TAG:1}"
+    ARCHIVE="supply-chain-$TAG.tar.gz"
+    MODULE="package_metadata"
+    STRIP_PREFIX="${PREFIX}/metadata",
+    ;;
+  * )
+    VERSION=$(echo "$TAG" | sed -e 's/^.*-//')
+    MODULE=$(echo "$TAG" | sed -e 's/-[0-9]*.*$//')
+    PREFIX="${TAG}"
+    ARCHIVE="${TAG}.tar.gz"
+    STRIP_PREFIX="${PREFIX}",
+esac
+
+echo TAG=$TAG
+echo VERSION=$VERSION
+echo ARCHIVE=$ARCHIVE
+echo MODULE=$MODULE
 
 # NB: configuration for 'git archive' is in /.gitattributes
-git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+echo git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+git archive --format=tar --prefix=${PREFIX}/ head | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat << EOF
@@ -22,7 +41,7 @@ cat << EOF
 2. Add to your \`MODULE.bazel\` file:
 
 \`\`\`starlark
-bazel_dep(name = "package_metadata", version = "${TAG:1}")
+bazel_dep(name = "${MODULE}", version = "${VERSION}")
 \`\`\`
 
 ## Using WORKSPACE
@@ -32,9 +51,9 @@ Paste this snippet into your \`WORKSPACE.bazel\` file:
 \`\`\`starlark
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
-    name = "package_metadata",
+    name = "${MODULE}",
     sha256 = "${SHA}",
-    strip_prefix = "${PREFIX}/metadata",
+    strip_prefix = "${STRIP_PREFIX}",
     url = "https://github.com/bazel-contrib/supply-chain/releases/download/${TAG}/${ARCHIVE}",
 )
 \`\`\`

--- a/.github/workflows/release_tools.yml
+++ b/.github/workflows/release_tools.yml
@@ -1,0 +1,87 @@
+name: "Create release of tools"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: "string"
+
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
+
+jobs:
+  ci:
+    name: "CI"
+    uses: "./.github/workflows/ci.yml"
+  
+  create_tag:
+    name: "Create tag"
+    runs-on:
+      - "ubuntu-latest"
+    needs:
+      - "ci"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Create tag"
+        id: "tag"
+        env:
+          VERSION: "${{ inputs.version }}"
+
+          GIT_AUTHOR_NAME: "${{ github.actor }}"
+          GIT_AUTHOR_EMAIL: "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "${{ github.actor }}"
+          GIT_COMMITTER_EMAIL: "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+        run: |
+          # Update `MODULE.bazel` and commit.
+          bzlmod_names=("supply_chain_tools")
+          bzlmod_directories=("tools")
+
+          for bzlmod_directory in "${bzlmod_directories[@]}"; do
+            for bzlmod_name in "${bzlmod_names[@]}"; do
+              sed -i -e "s/version = .. /version = \"${VERSION}\" /" "${bzlmod_directory}/MODULE.bazel"
+            done
+            git add "${bzlmod_directory}/MODULE.bazel"
+          done
+          git commit -m "Release `supply_chain-tools-${VERSION}`"
+
+          # Push release tag.
+          git tag "supply_chain-tools-${VERSION}" "HEAD"
+          git push origin "supply_chain-tools-${VERSION}"
+
+  release:
+    name: "Create GitHub release"
+    needs:
+      - "create_tag"
+
+    uses: "bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.4"
+    with:
+      # The workflow appends `--disk_cache` here. There seems to be now way to
+      # opt out, so use `echo || false` to make it a noop.
+      bazel_test_command: echo "Already executed by step 'CI'" || false
+      release_files: "supply_chain_tools-*.tar.gz"
+      prerelease: "true"
+      tag_name: "supply_chain_tools-${{ inputs.version }}"
+
+# Next PR, after we test process.
+#  publish:
+#    name: "Publish to BCR"
+#    needs:
+#      - "release"
+#
+#    permissions:
+#      attestations: write
+#      contents: write
+#      id-token: write
+#
+#    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.0.0"
+#    with:
+#      tag_name: "supply_chain-tools-${{ inputs.version }}"
+#      registry_fork: "bazel-contrib/bazel-central-registry"
+#      draft: false
+#    secrets:
+#      publish_token: "${{ secrets.BCR_PUBLISH_TOKEN }}"

--- a/.github/workflows/release_tools.yml
+++ b/.github/workflows/release_tools.yml
@@ -37,13 +37,19 @@ jobs:
           GIT_COMMITTER_NAME: "${{ github.actor }}"
           GIT_COMMITTER_EMAIL: "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
         run: |
+
+          # Download `buildozer`
+          #
+          # TODO(yannic): Use `RUNNER_TOOL_CACHE` and cache between runs?
+          curl -o "${RUNNER_TEMP}/buildozer" -L "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildozer-linux-amd64"
+          chmod +x "${RUNNER_TEMP}/buildozer"
           # Update `MODULE.bazel` and commit.
           bzlmod_names=("supply_chain_tools")
           bzlmod_directories=("tools")
 
           for bzlmod_directory in "${bzlmod_directories[@]}"; do
             for bzlmod_name in "${bzlmod_names[@]}"; do
-              sed -i -e "s/version = .. /version = \"${VERSION}\" /" "${bzlmod_directory}/MODULE.bazel"
+              "${RUNNER_TEMP}/buildozer" "set version ${VERSION}" "//${bzlmod_directory}/MODULE.bazel:${bzlmod_name}" || true
             done
             git add "${bzlmod_directory}/MODULE.bazel"
           done

--- a/tools/MODULE.bazel
+++ b/tools/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "supply_chain_tools",
-    version = "0.0.1",
+    version = "",  # Automatically updated by release pipeline.
 )
 
 # Do not update to newer versions until you need a specific new feature.


### PR DESCRIPTION
The tag and release is named: supply_chain_tools-<VERSION>
The goal is to release only the subset of files under tools, so the strip_prefix is idential to the tag.

- release_prep.sh should maintain parity with the metadata tooling that uses the v1.2.3 scheme
  - But we should punt that and give it the name metadata-1.2.3.
- Does not push to BCR yet.

Design question:
- Do we create separte workflows for each of the repos, or make that an input?
- If it's an input, we need to make the publish to bcr contingent on name, becaue docs and example don't make as much sense there.