### PR TITLE
Fix error if there is no transitive metadata info

### DIFF
--- a/tools/sbom/sbom.bzl
+++ b/tools/sbom/sbom.bzl
@@ -13,16 +13,17 @@ def _sbom_impl(ctx):
     transitive_inputs = []
     config = { "deps": [] }
     seen_metadata = {}
-    for transitive_metadata in transitive_metadata_info.trans.to_list():
-        for m in transitive_metadata.metadata.to_list():
-            if hasattr(m, "metadata"):
-                path = m.metadata.path
-                if path not in seen_metadata:
-                    seen_metadata[path] = True
-                    config["deps"].append({
-                        "metadata": path,
-                    })
-                    transitive_inputs.append(m.files)
+    if hasattr(transitive_metadata_info, "trans"):
+        for transitive_metadata in transitive_metadata_info.trans.to_list():
+            for m in transitive_metadata.metadata.to_list():
+                if hasattr(m, "metadata"):
+                    path = m.metadata.path
+                    if path not in seen_metadata:
+                        seen_metadata[path] = True
+                        config["deps"].append({
+                            "metadata": path,
+                        })
+                        transitive_inputs.append(m.files)
 
     sbom_gen_config = ctx.actions.declare_file("{name}.sbom.config.json".format(name=ctx.attr.name))
     ctx.actions.write(sbom_gen_config, json.encode(config))


### PR DESCRIPTION
I wanted to introduce the sbom tool before I add metadata to packages and this blocked it.

Error:
```
ERROR: [...]/BUILD:27:5: in sbom rule //[...]:sbom:
Traceback (most recent call last):
        File "[...]/external/supply_chain_tools+/sbom/sbom.bzl", line 15, column 56, in _sbom_impl
                for transitive_metadata in transitive_metadata_info.trans.to_list():
Error: 'TransitiveMetadataInfo' value has no field or method 'trans'
Available attributes:
```