### PR TITLE
Deduplicate packages when generating SPDX and CycloneDX output.

### DIFF
--- a/tools/sbom/sbom.bzl
+++ b/tools/sbom/sbom.bzl
@@ -12,13 +12,17 @@ def _sbom_impl(ctx):
     transitive_metadata_info = ctx.attr.target[TransitiveMetadataInfo]
     transitive_inputs = []
     config = { "deps": [] }
+    seen_metadata = {}
     for transitive_metadata in transitive_metadata_info.trans.to_list():
         for m in transitive_metadata.metadata.to_list():
             if hasattr(m, "metadata"):
-                config["deps"].append({
-                    "metadata": m.metadata.path
-                })
-                transitive_inputs.append(m.files)
+                path = m.metadata.path
+                if path not in seen_metadata:
+                    seen_metadata[path] = True
+                    config["deps"].append({
+                        "metadata": path,
+                    })
+                    transitive_inputs.append(m.files)
 
     sbom_gen_config = ctx.actions.declare_file("{name}.sbom.config.json".format(name=ctx.attr.name))
     ctx.actions.write(sbom_gen_config, json.encode(config))


### PR DESCRIPTION
The same dependency can be included in the target from multiple dependencies. Current implementation just included all dependencies without de-duplication which produced a large sbom output with a lot of duplicates.

Fixes: https://github.com/bazel-contrib/supply-chain/issues/125