### PR TITLE
Use full name with namespace when available

### DIFF
--- a/lib/supplychain-go/cmd/cyclonedx/cyclonedx.go
+++ b/lib/supplychain-go/cmd/cyclonedx/cyclonedx.go
@@ -80,10 +80,16 @@ func GenerateBOM(config sbom.GenConfig) (*cdx.BOM, error) {
 		}
 
 		purl := pkgMetadata.GetPURL()
+
+		fullName := purl.Name
+		if purl.Namespace != "" {
+			fullName = purl.Namespace + "/" + fullName
+		}
+
 		component := cdx.Component{
 			BOMRef:     purl.String(),
 			Type:       cdx.ComponentTypeLibrary,
-			Name:       purl.Name,
+			Name:       fullName,
 			PackageURL: purl.String(),
 		}
 


### PR DESCRIPTION
With golang, [namespace is important](https://github.com/package-url/purl-spec/blob/main/types-doc/golang-definition.md#namespace-definition), otherwise the name associated to a purl can be the version at the end :
* `github.com/jackc/pgx/v5` would have a name of `v5`

cargo purl on the other [doesn't have namespace](https://github.com/package-url/purl-spec/blob/main/types-doc/cargo-definition.md#namespace-definition)