### PR TITLE
supply_chain_tools: Use Go tools in exec configuration

### DIFF
--- a/tools/sbom/cyclonedx.bzl
+++ b/tools/sbom/cyclonedx.bzl
@@ -13,7 +13,7 @@ def _cyclonedx_impl(ctx):
     ctx.actions.run(
         outputs = [out],
         inputs = inputs,
-        executable = ctx.attr._cyclonedx[DefaultInfo].files_to_run.executable,
+        executable = ctx.attr._cyclonedx[DefaultInfo].files_to_run,
         arguments = [
             "--config",
             ctx.attr.sbom[SbomInfo].config.path,
@@ -31,6 +31,6 @@ cyclonedx = rule(
         "sbom": attr.label(doc = "The sbom target to generate the CycloneDX SBOM from."),
         "format": attr.string(default = "json", values = ["json", "xml"], doc = "The output format for the CycloneDX SBOM."),
         "out": attr.output(doc = "The output file for the CycloneDX SBOM."),
-        "_cyclonedx": attr.label(default = "@supply-chain-go//cmd/cyclonedx", doc = "The cyclonedx tool to use."),
+        "_cyclonedx": attr.label(default = "@supply-chain-go//cmd/cyclonedx", doc = "The cyclonedx tool to use.", executable = True, cfg = "exec"),
     },
 )

--- a/tools/sbom/spdx.bzl
+++ b/tools/sbom/spdx.bzl
@@ -11,10 +11,10 @@ def _spdx_impl(ctx):
         ],
     )
     ctx.actions.run(
-        outputs=[out],
-        inputs=inputs,
-        executable=ctx.attr._spdx[DefaultInfo].files_to_run.executable,
-        arguments=[
+        outputs = [out],
+        inputs = inputs,
+        executable = ctx.attr._spdx[DefaultInfo].files_to_run,
+        arguments = [
             "--config",
             ctx.attr.sbom[SbomInfo].config.path,
             "--out",
@@ -23,7 +23,7 @@ def _spdx_impl(ctx):
             ctx.attr.format,
         ],
     )
-    return DefaultInfo(files=depset([out]))
+    return DefaultInfo(files = depset([out]))
 
 spdx = rule(
     _spdx_impl,
@@ -31,6 +31,6 @@ spdx = rule(
         "sbom": attr.label(doc = "The sbom target to generate the SPDX SBOM from."),
         "format": attr.string(default = "json", values = ["json", "yaml", "tag-value"], doc = "The output format for the SPDX SBOM."),
         "out": attr.output(doc = "The output file for the SPDX SBOM."),
-        "_spdx": attr.label(default = "@supply-chain-go//cmd/spdx", doc = "The spdx tool to use."),
-    }
+        "_spdx": attr.label(default = "@supply-chain-go//cmd/spdx", doc = "The spdx tool to use.", executable = True, cfg = "exec"),
+    },
 )


### PR DESCRIPTION
The tools are used in a build action, so they should set `cfg = "exec"`. Without this, I'm seeing issues when cross compiling (via --platforms=).

```
bazel-out/darwin_arm64-fastbuild/bin/external/supply-chain-go+/cmd/cyclonedx/cyclonedx_/cyclonedx: bazel-out/darwin_arm64-fastbuild/bin/external/supply-chain-go+/cmd/cyclonedx/cyclonedx_/cyclonedx: cannot execute binary file
```