### PR TITLE
gather_metadata: Support dict-typed attributes

### DIFF
--- a/tools/gather_metadata/BUILD
+++ b/tools/gather_metadata/BUILD
@@ -5,6 +5,7 @@ load("@bazel_skylib//lib:unittest.bzl", "unittest")
 load(":integration_test.bzl", "integration_test_suite")
 load(":serialization_integration_test.bzl", "serialization_integration_test_suite")
 load(":filtering_test.bzl", "filtering_test_suite")
+load(":attr_types_test.bzl", "attr_types_test_suite")
 
 package(
     default_package_metadata = ["//:package_metadata"],
@@ -38,11 +39,14 @@ serialization_integration_test_suite(name = "serialization_integration_tests")
 
 filtering_test_suite(name = "filtering_tests")
 
+attr_types_test_suite(name = "attr_types_tests")
+
 test_suite(
     name = "all_tests",
     tests = [
         ":integration_tests",
         ":serialization_integration_tests",
         ":filtering_tests",
+        ":attr_types_tests",
     ],
 )

--- a/tools/gather_metadata/attr_types_test.bzl
+++ b/tools/gather_metadata/attr_types_test.bzl
@@ -1,0 +1,178 @@
+"""Tests that dependency edges are gathered through every attribute type.
+
+The metadata gathering aspect must follow dependency edges regardless of the
+attribute type that declares them: plain ``label`` attributes, ``label_list``
+attributes, ``label_keyed_string_dict`` attributes (targets in the dict keys)
+and ``string_keyed_label_dict`` attributes (targets in the dict values). These
+tests define a small rule for each attribute shape and assert that a
+metadata-carrying dependency reached *only* through that attribute is captured
+in the resulting TransitiveMetadataInfo (both as a transitive node and as a
+direct edge).
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load(":gather_metadata.bzl", "gather_metadata_info")
+load(":providers.bzl", "TransitiveMetadataInfo")
+
+def _consume_impl(_ctx):
+    return [DefaultInfo()]
+
+# A rule per attribute shape that can carry dependency edges. Each simply
+# depends on its input(s); the metadata is attached via the package's
+# default_package_metadata, so any traversed dependency shows up in the graph.
+_label_attr_rule = rule(
+    implementation = _consume_impl,
+    attrs = {"dep": attr.label()},
+)
+
+_label_list_attr_rule = rule(
+    implementation = _consume_impl,
+    attrs = {"deps": attr.label_list()},
+)
+
+_label_keyed_string_dict_attr_rule = rule(
+    implementation = _consume_impl,
+    attrs = {"deps": attr.label_keyed_string_dict()},
+)
+
+_string_keyed_label_dict_attr_rule = rule(
+    implementation = _consume_impl,
+    attrs = {"deps": attr.string_keyed_label_dict()},
+)
+
+def _run_check(ctx, dep_suffix):
+    """Asserts the dependency `:dep_suffix` was gathered by the aspect."""
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+    info = target_under_test[TransitiveMetadataInfo]
+
+    all_targets = info.transitive.to_list()
+    labels = [str(twmi.target) for twmi in all_targets]
+
+    # 1. The dependency reached through the attribute must appear as a node in
+    #    the transitive metadata set.
+    reached = [label for label in labels if label.endswith(":" + dep_suffix)]
+    asserts.true(
+        env,
+        len(reached) > 0,
+        "Expected dependency ':{}' to be gathered through the attribute, got {}".format(
+            dep_suffix,
+            labels,
+        ),
+    )
+
+    # 2. The edge from the target under test to that dependency must be recorded
+    #    in direct_deps for graph/SBOM generation.
+    direct_deps = None
+    for twmi in all_targets:
+        if twmi.target == target_under_test.label:
+            direct_deps = [str(dep) for dep in twmi.direct_deps]
+
+    asserts.true(
+        env,
+        direct_deps != None,
+        "Target under test should have its own metadata entry",
+    )
+    if direct_deps != None:
+        edges = [dep for dep in direct_deps if dep.endswith(":" + dep_suffix)]
+        asserts.true(
+            env,
+            len(edges) > 0,
+            "Expected a direct edge to ':{}', got {}".format(dep_suffix, direct_deps),
+        )
+
+    return analysistest.end(env)
+
+def _via_label_test_impl(ctx):
+    return _run_check(ctx, "label_leaf")
+
+def _via_label_list_test_impl(ctx):
+    return _run_check(ctx, "label_list_leaf")
+
+def _via_dict_test_impl(ctx):
+    return _run_check(ctx, "dict_leaf")
+
+def _via_string_keyed_dict_test_impl(ctx):
+    return _run_check(ctx, "string_keyed_dict_leaf")
+
+via_label_test = analysistest.make(
+    _via_label_test_impl,
+    extra_target_under_test_aspects = [gather_metadata_info],
+)
+
+via_label_list_test = analysistest.make(
+    _via_label_list_test_impl,
+    extra_target_under_test_aspects = [gather_metadata_info],
+)
+
+via_dict_test = analysistest.make(
+    _via_dict_test_impl,
+    extra_target_under_test_aspects = [gather_metadata_info],
+)
+
+via_string_keyed_dict_test = analysistest.make(
+    _via_string_keyed_dict_test_impl,
+    extra_target_under_test_aspects = [gather_metadata_info],
+)
+
+def attr_types_test_suite(name):
+    """Creates the per-attribute-type traversal test suite.
+
+    Args:
+      name: the name of the generated test_suite target.
+    """
+
+    # Each leaf is reachable exclusively through one attribute type, so a test
+    # passing proves that specific attribute type is traversed.
+    native.filegroup(name = "label_leaf", srcs = [], tags = ["manual"])
+    native.filegroup(name = "label_list_leaf", srcs = [], tags = ["manual"])
+    native.filegroup(name = "dict_leaf", srcs = [], tags = ["manual"])
+    native.filegroup(name = "string_keyed_dict_leaf", srcs = [], tags = ["manual"])
+
+    _label_attr_rule(
+        name = "via_label",
+        dep = ":label_leaf",
+        tags = ["manual"],
+    )
+    _label_list_attr_rule(
+        name = "via_label_list",
+        deps = [":label_list_leaf"],
+        tags = ["manual"],
+    )
+    _label_keyed_string_dict_attr_rule(
+        name = "via_dict",
+        deps = {":dict_leaf": "unused-value"},
+        tags = ["manual"],
+    )
+    _string_keyed_label_dict_attr_rule(
+        name = "via_string_keyed_dict",
+        deps = {"unused-key": ":string_keyed_dict_leaf"},
+        tags = ["manual"],
+    )
+
+    via_label_test(
+        name = "via_label_test",
+        target_under_test = ":via_label",
+    )
+    via_label_list_test(
+        name = "via_label_list_test",
+        target_under_test = ":via_label_list",
+    )
+    via_dict_test(
+        name = "via_dict_test",
+        target_under_test = ":via_dict",
+    )
+    via_string_keyed_dict_test(
+        name = "via_string_keyed_dict_test",
+        target_under_test = ":via_string_keyed_dict",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":via_label_test",
+            ":via_label_list_test",
+            ":via_dict_test",
+            ":via_string_keyed_dict_test",
+        ],
+    )

--- a/tools/gather_metadata/core.bzl
+++ b/tools/gather_metadata/core.bzl
@@ -70,8 +70,21 @@ def _get_transitive_metadata(
 
         attr_value = getattr(ctx.rule.attr, name)
 
-        # Make scalers into a lists for convenience.
-        if type(attr_value) != type([]):
+        # Flatten any attribute type into a flat list of targets.
+        if type(attr_value) == type({}):
+            # Dict-typed attrs: collect all targets from keys and values.
+            flat = []
+            for k, v in attr_value.items():
+                if type(k) == "Target":
+                    flat.append(k)
+                elif type(k) == type([]):
+                    flat.extend(k)
+                if type(v) == "Target":
+                    flat.append(v)
+                elif type(v) == type([]):
+                    flat.extend(v)
+            attr_value = flat
+        elif type(attr_value) != type([]):
             attr_value = [attr_value]
 
         for dep in attr_value:

--- a/tools/gather_metadata/core.bzl
+++ b/tools/gather_metadata/core.bzl
@@ -44,6 +44,46 @@ def should_traverse(ctx, attr, user_filters = None):
                 return False
     return True
 
+def _attr_targets(attr_value):
+    """Flattens a single rule attribute value into a list of its targets.
+
+    Rule attributes that carry dependency edges come in a few shapes, and each
+    needs to be flattened differently before we can walk the targets it points
+    at:
+
+      * ``label`` attributes resolve to a single ``Target``,
+      * ``label_list`` attributes resolve to a ``list`` of ``Target``s,
+      * ``label_keyed_string_dict`` (and dict-typed attributes in general)
+        resolve to a ``dict`` whose keys and/or values may be ``Target``s or
+        lists of ``Target``s.
+
+    Any other attribute type (e.g. strings, ints, bools and their list/dict
+    variants) carries no targets and flattens to an empty list.
+
+    Args:
+      attr_value: the value of a single rule attribute, as returned by
+        ``getattr(ctx.rule.attr, name)``.
+
+    Returns:
+      A flat list containing every ``Target`` found in ``attr_value``.
+    """
+    if type(attr_value) == "Target":
+        return [attr_value]
+    if type(attr_value) == type([]):
+        return [item for item in attr_value if type(item) == "Target"]
+    if type(attr_value) == type({}):
+        # Inspect both keys and values so that any dict-typed attribute (e.g.
+        # label_keyed_string_dict, whose keys are targets) is covered.
+        targets = []
+        for key, value in attr_value.items():
+            for entry in (key, value):
+                if type(entry) == "Target":
+                    targets.append(entry)
+                elif type(entry) == type([]):
+                    targets.extend([item for item in entry if type(item) == "Target"])
+        return targets
+    return []
+
 def _get_transitive_metadata(
         ctx,
         transitive_depsets,
@@ -72,22 +112,12 @@ def _get_transitive_metadata(
         if filter_func and not filter_func(ctx, name):
             continue
 
-        attr_value = getattr(ctx.rule.attr, name)
-
-        # Make scalers into a lists for convenience.
-        if type(attr_value) != type([]):
-            attr_value = [attr_value]
-
-        for dep in attr_value:
-            # Ignore anything that isn't a target
-            if type(dep) != "Target":
-                continue
-
-            # Targets can also include things like input files that won't have the
-            # aspect, so we additionally check for the aspect rather than assume
-            # it's on all targets.  Even some regular targets may be synthetic and
-            # not have the aspect. This provides protection against those outlier
-            # cases.
+        for dep in _attr_targets(getattr(ctx.rule.attr, name)):
+            # Targets can also include things like input files that won't have
+            # the aspect, so we additionally check for the aspect rather than
+            # assume it's on all targets. Even some regular targets may be
+            # synthetic and not have the aspect. This provides protection
+            # against those outlier cases.
             if provider in dep:
                 info = dep[provider]
                 if info != null_provider_instance:


### PR DESCRIPTION
Flatten dict-typed attributes (string_keyed_label_dict, label_keyed_string_dict, label_list_dict) into the target list so their targets are traversed for metadata collection.