### PR TITLE
[metadata] Fix logic bugs in PURL validation, normalization, and builder

### DIFF
--- a/metadata/purl/private/builder.bzl
+++ b/metadata/purl/private/builder.bzl
@@ -103,7 +103,7 @@ def build(
         components.append("/")
 
     # Append the percent-encoded name to the PURL.
-    components.append(purl.name)
+    components.append(percent_encode(purl.name))
 
     # If the version is not empty:
     if purl.version:

--- a/metadata/purl/private/normalization/normalization.bzl
+++ b/metadata/purl/private/normalization/normalization.bzl
@@ -13,7 +13,7 @@ def normalize(
         qualifiers = {},
         subpath = None):
     if not type:
-        None, "Mandatory property 'type' not set"
+        return None, "Mandatory property 'type' not set"
 
     # TODO(yannic): Implement normalization.
 

--- a/metadata/purl/private/validation/validation.bzl
+++ b/metadata/purl/private/validation/validation.bzl
@@ -50,8 +50,6 @@ def validate(
 
                 return "Qualifier key {} does not start with ASCII letter, got {}".format(key, c)
 
-    return None
-
     validator = _validators.get(type)
     if not validator:
         return None


### PR DESCRIPTION
## Summary

Fixes three logic bugs discovered during code audit:

- **normalization.bzl**: Missing `return` statement caused type validation errors to be silently ignored
- **builder.bzl**: Name component was not percent-encoded despite comment and spec requirement
- **validation.bzl**: Premature `return None` made type-specific validator lookup code unreachable

## Test plan

- [x] All existing tests pass (`bazel test //...`)
- [x] No behavioral changes to existing test cases
- [x] Fixes enable proper error handling and PURL spec compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)