### PR TITLE
[metadata] Improve purl.builder() documentation

### DIFF
--- a/docs/metadata/defs.md
+++ b/docs/metadata/defs.md
@@ -171,7 +171,67 @@ load("@package_metadata//:defs.bzl", "purl")
 purl.builder()
 </pre>
 
+Creates a fluent builder for constructing Package URLs (PURLs).
+
+The builder provides a chainable interface for constructing PURLs according to
+the [Package URL specification](https://github.com/package-url/purl-spec).
+
+The `type` and `name` fields are required. All components are validated and
+normalized according to the PURL spec. Components are automatically percent-encoded
+where necessary, and qualifiers are sorted lexicographically in the output.
+
+Example - Simple PURL:
+
+    load("@package_metadata//purl:purl.bzl", "purl")
+
+    my_purl = (purl.builder()
+        .type("npm")
+        .name("foobar")
+        .version("12.3.1")
+        .build())
+    # Result: pkg:npm/foobar@12.3.1
+
+Example - Maven with namespace and qualifiers:
+
+    load("@package_metadata//purl:purl.bzl", "purl")
+
+    my_purl = (purl.builder()
+        .type("maven")
+        .namespace("org.apache.xmlgraphics")
+        .name("batik-anim")
+        .version("1.9.1")
+        .add_qualifier("classifier", "sources")
+        .add_qualifier("repository_url", "https://repo.spring.io/release")
+        .build())
+    # Result: pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=https%3A%2F%2Frepo.spring.io%2Frelease
+
+Example - Golang with namespace and subpath:
+
+    load("@package_metadata//purl:purl.bzl", "purl")
+
+    my_purl = (purl.builder()
+        .type("golang")
+        .namespace("google.golang.org")
+        .name("genproto")
+        .version("abcdedf")
+        .subpath("googleapis/api/annotations")
+        .build())
+    # Result: pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations
 
 
+
+**RETURNS**
+
+A builder object with chainable methods:
+
+  - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
+  - `namespace(namespace)`: Sets the namespace (optional). String with segments separated by '/'.
+  - `name(name)`: Sets the package name (required).
+  - `version(version)`: Sets the package version (optional).
+  - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
+    Key must start with ASCII letter and contain only lowercase letters,
+    numbers, '.', '-', '_'.
+  - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
+  - `build()`: Constructs the final PURL string. Fails on validation errors.
 
 

--- a/docs/metadata/defs.md
+++ b/docs/metadata/defs.md
@@ -180,6 +180,9 @@ The `type` and `name` fields are required. All components are validated and
 normalized according to the PURL spec. Components are automatically percent-encoded
 where necessary, and qualifiers are sorted lexicographically in the output.
 
+For a list of supported PURL types and their specifications, see:
+https://github.com/package-url/purl-spec/blob/main/purl-types-index.json
+
 Example - Simple PURL:
 
     load("@package_metadata//purl:purl.bzl", "purl")
@@ -232,6 +235,8 @@ A builder object with chainable methods:
     Key must start with ASCII letter and contain only lowercase letters,
     numbers, '.', '-', '_'.
   - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
-  - `build()`: Constructs the final PURL string. Fails on validation errors.
+  - `build()`: Validates, normalizes, and constructs the final PURL string.
+    Performs both general and type-specific validation and normalization.
+    Fails if validation errors occur.
 
 

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -94,13 +94,13 @@ Example - PURL with namespace, qualifiers, and subpath:
         .build())
     # Result: pkg:maven/org.apache.commons/commons-lang3@3.12.0?classifier=sources&type=jar#src/main
 
-Example - Multi-segment namespaces:
+Example - Multi-segment namespace:
 
     load("@package_metadata//purl:purl.bzl", "purl")
 
     my_purl = (purl.builder()
         .type("golang")
-        .namespace(["github.com", "user", "project"])
+        .namespace("github.com/user/project")
         .name("package")
         .build())
     # Result: pkg:golang/github.com/user/project/package
@@ -112,13 +112,13 @@ Example - Multi-segment namespaces:
 A builder object with chainable methods:
 
   - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
-  - `namespace(namespace)`: Sets the namespace (optional). String or list of strings.
+  - `namespace(namespace)`: Sets the namespace (optional). String with segments separated by '/'.
   - `name(name)`: Sets the package name (required).
   - `version(version)`: Sets the package version (optional).
   - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
     Key must start with ASCII letter and contain only lowercase letters,
     numbers, '.', '-', '_'.
-  - `subpath(subpath)`: Sets the subpath (optional). List of path segments.
+  - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
   - `build()`: Constructs the final PURL string. Fails on validation errors.
 
 

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -123,6 +123,8 @@ A builder object with chainable methods:
     Key must start with ASCII letter and contain only lowercase letters,
     numbers, '.', '-', '_'.
   - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
-  - `build()`: Constructs the final PURL string. Fails on validation errors.
+  - `build()`: Validates, normalizes, and constructs the final PURL string.
+    Performs both general and type-specific validation and normalization.
+    Fails if validation errors occur.
 
 

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -68,6 +68,9 @@ The `type` and `name` fields are required. All components are validated and
 normalized according to the PURL spec. Components are automatically percent-encoded
 where necessary, and qualifiers are sorted lexicographically in the output.
 
+For a list of supported PURL types and their specifications, see:
+https://github.com/package-url/purl-spec/blob/main/purl-types-index.json
+
 Example - Simple PURL:
 
     load("@package_metadata//purl:purl.bzl", "purl")

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -110,14 +110,15 @@ Example - Multi-segment namespaces:
 **RETURNS**
 
 A builder object with chainable methods:
-      - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
-      - `namespace(namespace)`: Sets the namespace (optional). String or list of strings.
-      - `name(name)`: Sets the package name (required).
-      - `version(version)`: Sets the package version (optional).
-      - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
-          Key must start with ASCII letter and contain only lowercase letters,
-          numbers, '.', '-', '_'.
-      - `subpath(subpath)`: Sets the subpath (optional). List of path segments.
-      - `build()`: Constructs the final PURL string. Fails on validation errors.
+
+  - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
+  - `namespace(namespace)`: Sets the namespace (optional). String or list of strings.
+  - `name(name)`: Sets the package name (required).
+  - `version(version)`: Sets the package version (optional).
+  - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
+    Key must start with ASCII letter and contain only lowercase letters,
+    numbers, '.', '-', '_'.
+  - `subpath(subpath)`: Sets the subpath (optional). List of path segments.
+  - `build()`: Constructs the final PURL string. Fails on validation errors.
 
 

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -59,7 +59,65 @@ load("@package_metadata//purl:purl.bzl", "purl")
 purl.builder()
 </pre>
 
+Creates a fluent builder for constructing Package URLs (PURLs).
+
+The builder provides a chainable interface for constructing PURLs according to
+the [Package URL specification](https://github.com/package-url/purl-spec).
+
+The `type` and `name` fields are required. All components are validated and
+normalized according to the PURL spec. Components are automatically percent-encoded
+where necessary, and qualifiers are sorted lexicographically in the output.
+
+Example - Simple PURL:
+
+    load("@package_metadata//purl:purl.bzl", "purl")
+
+    my_purl = (purl.builder()
+        .type("npm")
+        .name("lodash")
+        .version("4.17.21")
+        .build())
+    # Result: pkg:npm/lodash@4.17.21
+
+Example - PURL with namespace, qualifiers, and subpath:
+
+    load("@package_metadata//purl:purl.bzl", "purl")
+
+    my_purl = (purl.builder()
+        .type("maven")
+        .namespace("org.apache.commons")
+        .name("commons-lang3")
+        .version("3.12.0")
+        .add_qualifier("classifier", "sources")
+        .add_qualifier("type", "jar")
+        .subpath(["src", "main"])
+        .build())
+    # Result: pkg:maven/org.apache.commons/commons-lang3@3.12.0?classifier=sources&type=jar#src/main
+
+Example - Multi-segment namespaces:
+
+    load("@package_metadata//purl:purl.bzl", "purl")
+
+    my_purl = (purl.builder()
+        .type("golang")
+        .namespace(["github.com", "user", "project"])
+        .name("package")
+        .build())
+    # Result: pkg:golang/github.com/user/project/package
 
 
+
+**RETURNS**
+
+A builder object with chainable methods:
+      - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
+      - `namespace(namespace)`: Sets the namespace (optional). String or list of strings.
+      - `name(name)`: Sets the package name (required).
+      - `version(version)`: Sets the package version (optional).
+      - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
+          Key must start with ASCII letter and contain only lowercase letters,
+          numbers, '.', '-', '_'.
+      - `subpath(subpath)`: Sets the subpath (optional). List of path segments.
+      - `build()`: Constructs the final PURL string. Fails on validation errors.
 
 

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -74,36 +74,37 @@ Example - Simple PURL:
 
     my_purl = (purl.builder()
         .type("npm")
-        .name("lodash")
-        .version("4.17.21")
+        .name("foobar")
+        .version("12.3.1")
         .build())
-    # Result: pkg:npm/lodash@4.17.21
+    # Result: pkg:npm/foobar@12.3.1
 
-Example - PURL with namespace, qualifiers, and subpath:
+Example - Maven with namespace and qualifiers:
 
     load("@package_metadata//purl:purl.bzl", "purl")
 
     my_purl = (purl.builder()
         .type("maven")
-        .namespace("org.apache.commons")
-        .name("commons-lang3")
-        .version("3.12.0")
+        .namespace("org.apache.xmlgraphics")
+        .name("batik-anim")
+        .version("1.9.1")
         .add_qualifier("classifier", "sources")
-        .add_qualifier("type", "jar")
-        .subpath(["src", "main"])
+        .add_qualifier("repository_url", "https://repo.spring.io/release")
         .build())
-    # Result: pkg:maven/org.apache.commons/commons-lang3@3.12.0?classifier=sources&type=jar#src/main
+    # Result: pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=https%3A%2F%2Frepo.spring.io%2Frelease
 
-Example - Multi-segment namespace:
+Example - Golang with namespace and subpath:
 
     load("@package_metadata//purl:purl.bzl", "purl")
 
     my_purl = (purl.builder()
         .type("golang")
-        .namespace("github.com/user/project")
-        .name("package")
+        .namespace("google.golang.org")
+        .name("genproto")
+        .version("abcdedf")
+        .subpath("googleapis/api/annotations")
         .build())
-    # Result: pkg:golang/github.com/user/project/package
+    # Result: pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations
 
 
 

--- a/metadata/purl/private/builder.bzl
+++ b/metadata/purl/private/builder.bzl
@@ -114,6 +114,11 @@ def build(
     This function validates, normalizes, and serializes the PURL components
     according to the PURL specification (https://github.com/package-url/purl-spec).
 
+    Validation and normalization are performed in two stages:
+    1. General validation checks required fields and qualifier key constraints
+    2. Type-specific validation and normalization rules are applied based on the
+       package type (e.g., case normalization for npm, path handling for golang)
+
     Args:
         type: The package type (required). Must be lowercase ASCII string (e.g., "maven", "npm", "pypi").
         namespace: The package namespace (optional). String with segments separated by '/' (e.g., "org.apache.commons").

--- a/metadata/purl/private/builder.bzl
+++ b/metadata/purl/private/builder.bzl
@@ -131,11 +131,15 @@ def build(
         ```starlark
         purl, err = build(
             type = "maven",
-            namespace = "org.apache.commons",
-            name = "commons-lang3",
-            version = "3.12.0",
+            namespace = "org.apache.xmlgraphics",
+            name = "batik-anim",
+            version = "1.9.1",
+            qualifiers = {
+                "classifier": "sources",
+                "repository_url": "https://repo.spring.io/release",
+            },
         )
-        # purl: pkg:maven/org.apache.commons/commons-lang3@3.12.0
+        # purl: pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=https%3A%2F%2Frepo.spring.io%2Frelease
         # err: None
         ```
     """
@@ -241,49 +245,49 @@ def builder():
     The builder uses a fluent API pattern where methods can be chained together.
     Call `build()` at the end to construct the final PURL string.
 
-    Example:
-        ```starlark
-        purl = builder() \
-            .type("maven") \
-            .namespace("org.apache.commons") \
-            .name("commons-lang3") \
-            .version("3.12.0") \
-            .build()
-        # Result: pkg:maven/org.apache.commons/commons-lang3@3.12.0
-        ```
-
-    Example with qualifiers:
+    Example - Simple PURL:
         ```starlark
         purl = builder() \
             .type("npm") \
-            .name("express") \
-            .version("4.18.2") \
-            .add_qualifier("arch", "x64") \
-            .add_qualifier("os", "linux") \
+            .name("foobar") \
+            .version("12.3.1") \
             .build()
-        # Result: pkg:npm/express@4.18.2?arch=x64&os=linux
+        # Result: pkg:npm/foobar@12.3.1
         ```
 
-    Example with subpath:
+    Example - Maven with namespace and qualifiers:
         ```starlark
         purl = builder() \
-            .type("github") \
-            .namespace("curl") \
-            .name("curl") \
-            .version("7.72.0") \
-            .subpath(["lib", "vtls"]) \
+            .type("maven") \
+            .namespace("org.apache.xmlgraphics") \
+            .name("batik-anim") \
+            .version("1.9.1") \
+            .add_qualifier("classifier", "sources") \
+            .add_qualifier("repository_url", "https://repo.spring.io/release") \
             .build()
-        # Result: pkg:github/curl/curl@7.72.0#lib/vtls
+        # Result: pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=https%3A%2F%2Frepo.spring.io%2Frelease
+        ```
+
+    Example - Golang with namespace and subpath:
+        ```starlark
+        purl = builder() \
+            .type("golang") \
+            .namespace("google.golang.org") \
+            .name("genproto") \
+            .version("abcdedf") \
+            .subpath("googleapis/api/annotations") \
+            .build()
+        # Result: pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations
         ```
 
     Returns:
         A builder object with the following methods:
             - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
-            - `namespace(namespace)`: Sets the namespace. Can be a string or list of strings for multi-segment namespaces.
+            - `namespace(namespace)`: Sets the namespace (optional). String with segments separated by '/'.
             - `name(name)`: Sets the package name (required).
             - `version(version)`: Sets the package version (optional).
             - `add_qualifier(name, value)`: Adds a qualifier key-value pair (optional). Key must start with ASCII letter and contain only lowercase letters, numbers, '.', '-', '_'.
-            - `subpath(subpath)`: Sets the subpath. Must be a list of strings representing path segments (optional).
+            - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
             - `build()`: Constructs and returns the PURL string. Fails if validation errors occur.
     """
 

--- a/metadata/purl/private/builder.bzl
+++ b/metadata/purl/private/builder.bzl
@@ -57,6 +57,37 @@ def build(
         version = None,
         qualifiers = {},
         subpath = None):
+    """Builds a Package URL (PURL) string from component parts.
+
+    This function validates, normalizes, and serializes the PURL components
+    according to the PURL specification (https://github.com/package-url/purl-spec).
+
+    Args:
+        type: The package type (required). Must be lowercase ASCII string (e.g., "maven", "npm", "pypi").
+        namespace: The package namespace (optional). Can be a string or list of strings for multi-segment namespaces.
+        name: The package name (required). Will be percent-encoded in the output.
+        version: The package version (optional). Will be percent-encoded in the output.
+        qualifiers: A dictionary of qualifier key-value pairs (optional). Keys must start with ASCII letter
+                    and contain only lowercase letters, numbers, '.', '-', '_'. Values will be percent-encoded.
+        subpath: A list of path segments (optional). Each segment will be percent-encoded.
+
+    Returns:
+        A tuple of (purl_string, error). On success, returns (purl_string, None).
+        On failure, returns (None, error_message).
+
+    Example:
+        ```starlark
+        purl, err = build(
+            type = "maven",
+            namespace = "org.apache.commons",
+            name = "commons-lang3",
+            version = "3.12.0",
+        )
+        # purl: pkg:maven/org.apache.commons/commons-lang3@3.12.0
+        # err: None
+        ```
+    """
+
     err = validate(
         type = type,
         namespace = namespace,
@@ -153,6 +184,57 @@ def build(
     return "".join(components), None
 
 def builder():
+    """Creates a fluent builder for constructing Package URLs (PURLs).
+
+    The builder uses a fluent API pattern where methods can be chained together.
+    Call `build()` at the end to construct the final PURL string.
+
+    Example:
+        ```starlark
+        purl = builder() \
+            .type("maven") \
+            .namespace("org.apache.commons") \
+            .name("commons-lang3") \
+            .version("3.12.0") \
+            .build()
+        # Result: pkg:maven/org.apache.commons/commons-lang3@3.12.0
+        ```
+
+    Example with qualifiers:
+        ```starlark
+        purl = builder() \
+            .type("npm") \
+            .name("express") \
+            .version("4.18.2") \
+            .add_qualifier("arch", "x64") \
+            .add_qualifier("os", "linux") \
+            .build()
+        # Result: pkg:npm/express@4.18.2?arch=x64&os=linux
+        ```
+
+    Example with subpath:
+        ```starlark
+        purl = builder() \
+            .type("github") \
+            .namespace("curl") \
+            .name("curl") \
+            .version("7.72.0") \
+            .subpath(["lib", "vtls"]) \
+            .build()
+        # Result: pkg:github/curl/curl@7.72.0#lib/vtls
+        ```
+
+    Returns:
+        A builder object with the following methods:
+            - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
+            - `namespace(namespace)`: Sets the namespace. Can be a string or list of strings for multi-segment namespaces.
+            - `name(name)`: Sets the package name (required).
+            - `version(version)`: Sets the package version (optional).
+            - `add_qualifier(name, value)`: Adds a qualifier key-value pair (optional). Key must start with ASCII letter and contain only lowercase letters, numbers, '.', '-', '_'.
+            - `subpath(subpath)`: Sets the subpath. Must be a list of strings representing path segments (optional).
+            - `build()`: Constructs and returns the PURL string. Fails if validation errors occur.
+    """
+
     fields = {}
     self = struct(
         type = lambda type_name: _type(self, fields, type_name),

--- a/metadata/purl/private/builder.bzl
+++ b/metadata/purl/private/builder.bzl
@@ -309,7 +309,9 @@ def builder():
           Key must start with ASCII letter and contain only lowercase letters,
           numbers, '.', '-', '_'.
         - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
-        - `build()`: Constructs the final PURL string. Fails on validation errors.
+        - `build()`: Validates, normalizes, and constructs the final PURL string.
+          Performs both general and type-specific validation and normalization.
+          Fails if validation errors occur.
     """
 
     fields = {}

--- a/metadata/purl/private/builder.bzl
+++ b/metadata/purl/private/builder.bzl
@@ -119,6 +119,9 @@ def build(
     2. Type-specific validation and normalization rules are applied based on the
        package type (e.g., case normalization for npm, path handling for golang)
 
+    For a list of supported PURL types and their specifications, see:
+    https://github.com/package-url/purl-spec/blob/main/purl-types-index.json
+
     Args:
         type: The package type (required). Must be lowercase ASCII string (e.g., "maven", "npm", "pypi").
         namespace: The package namespace (optional). String with segments separated by '/' (e.g., "org.apache.commons").
@@ -253,6 +256,9 @@ def builder():
     The `type` and `name` fields are required. All components are validated and
     normalized according to the PURL spec. Components are automatically percent-encoded
     where necessary, and qualifiers are sorted lexicographically in the output.
+
+    For a list of supported PURL types and their specifications, see:
+    https://github.com/package-url/purl-spec/blob/main/purl-types-index.json
 
     Example - Simple PURL:
 

--- a/metadata/purl/private/builder.bzl
+++ b/metadata/purl/private/builder.bzl
@@ -9,26 +9,78 @@ visibility([
 ])
 
 def _type(self, fields, type_name):
+    """Sets the package type (required).
+
+    Args:
+        type_name: The package type as a lowercase ASCII string (e.g., "maven", "npm", "pypi").
+
+    Returns:
+        The builder instance for method chaining.
+    """
     fields["type"] = type_name
     return self
 
 def _namespace(self, fields, namespace):
+    """Sets the package namespace (optional).
+
+    Args:
+        namespace: The namespace as a string with segments separated by '/' (e.g., "org.apache.commons").
+                   Multi-segment namespaces like "github.com/user/project" are supported.
+
+    Returns:
+        The builder instance for method chaining.
+    """
     fields["namespace"] = namespace
     return self
 
 def _name(self, fields, name):
+    """Sets the package name (required).
+
+    Args:
+        name: The package name. Will be percent-encoded in the final PURL.
+
+    Returns:
+        The builder instance for method chaining.
+    """
     fields["name"] = name
     return self
 
 def _version(self, fields, version):
+    """Sets the package version (optional).
+
+    Args:
+        version: The package version. Will be percent-encoded in the final PURL.
+
+    Returns:
+        The builder instance for method chaining.
+    """
     fields["version"] = version
     return self
 
 def _add_qualifier(self, fields, name, value):
+    """Adds a qualifier key-value pair (optional, repeatable).
+
+    Args:
+        name: The qualifier key. Must start with an ASCII letter and contain only
+              lowercase letters, numbers, '.', '-', '_'.
+        value: The qualifier value. Will be percent-encoded in the final PURL.
+
+    Returns:
+        The builder instance for method chaining.
+    """
     fields.setdefault("qualifiers", {})[name] = value
     return self
 
 def _subpath(self, fields, subpath):
+    """Sets the subpath (optional).
+
+    Args:
+        subpath: The subpath as a string with segments separated by '/' (e.g., "src/main").
+                 Each segment will be percent-encoded in the final PURL.
+
+    Returns:
+        The builder instance for method chaining.
+    """
     fields["subpath"] = subpath
     return self
 
@@ -64,12 +116,12 @@ def build(
 
     Args:
         type: The package type (required). Must be lowercase ASCII string (e.g., "maven", "npm", "pypi").
-        namespace: The package namespace (optional). Can be a string or list of strings for multi-segment namespaces.
+        namespace: The package namespace (optional). String with segments separated by '/' (e.g., "org.apache.commons").
         name: The package name (required). Will be percent-encoded in the output.
         version: The package version (optional). Will be percent-encoded in the output.
         qualifiers: A dictionary of qualifier key-value pairs (optional). Keys must start with ASCII letter
                     and contain only lowercase letters, numbers, '.', '-', '_'. Values will be percent-encoded.
-        subpath: A list of path segments (optional). Each segment will be percent-encoded.
+        subpath: The subpath (optional). String with segments separated by '/' (e.g., "src/main").
 
     Returns:
         A tuple of (purl_string, error). On success, returns (purl_string, None).

--- a/metadata/purl/private/builder.bzl
+++ b/metadata/purl/private/builder.bzl
@@ -242,53 +242,63 @@ def build(
 def builder():
     """Creates a fluent builder for constructing Package URLs (PURLs).
 
-    The builder uses a fluent API pattern where methods can be chained together.
-    Call `build()` at the end to construct the final PURL string.
+    The builder provides a chainable interface for constructing PURLs according to
+    the [Package URL specification](https://github.com/package-url/purl-spec).
+
+    The `type` and `name` fields are required. All components are validated and
+    normalized according to the PURL spec. Components are automatically percent-encoded
+    where necessary, and qualifiers are sorted lexicographically in the output.
 
     Example - Simple PURL:
-        ```starlark
-        purl = builder() \
-            .type("npm") \
-            .name("foobar") \
-            .version("12.3.1") \
-            .build()
+
+        load("@package_metadata//purl:purl.bzl", "purl")
+
+        my_purl = (purl.builder()
+            .type("npm")
+            .name("foobar")
+            .version("12.3.1")
+            .build())
         # Result: pkg:npm/foobar@12.3.1
-        ```
 
     Example - Maven with namespace and qualifiers:
-        ```starlark
-        purl = builder() \
-            .type("maven") \
-            .namespace("org.apache.xmlgraphics") \
-            .name("batik-anim") \
-            .version("1.9.1") \
-            .add_qualifier("classifier", "sources") \
-            .add_qualifier("repository_url", "https://repo.spring.io/release") \
-            .build()
+
+        load("@package_metadata//purl:purl.bzl", "purl")
+
+        my_purl = (purl.builder()
+            .type("maven")
+            .namespace("org.apache.xmlgraphics")
+            .name("batik-anim")
+            .version("1.9.1")
+            .add_qualifier("classifier", "sources")
+            .add_qualifier("repository_url", "https://repo.spring.io/release")
+            .build())
         # Result: pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=https%3A%2F%2Frepo.spring.io%2Frelease
-        ```
 
     Example - Golang with namespace and subpath:
-        ```starlark
-        purl = builder() \
-            .type("golang") \
-            .namespace("google.golang.org") \
-            .name("genproto") \
-            .version("abcdedf") \
-            .subpath("googleapis/api/annotations") \
-            .build()
+
+        load("@package_metadata//purl:purl.bzl", "purl")
+
+        my_purl = (purl.builder()
+            .type("golang")
+            .namespace("google.golang.org")
+            .name("genproto")
+            .version("abcdedf")
+            .subpath("googleapis/api/annotations")
+            .build())
         # Result: pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations
-        ```
 
     Returns:
-        A builder object with the following methods:
-            - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
-            - `namespace(namespace)`: Sets the namespace (optional). String with segments separated by '/'.
-            - `name(name)`: Sets the package name (required).
-            - `version(version)`: Sets the package version (optional).
-            - `add_qualifier(name, value)`: Adds a qualifier key-value pair (optional). Key must start with ASCII letter and contain only lowercase letters, numbers, '.', '-', '_'.
-            - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
-            - `build()`: Constructs and returns the PURL string. Fails if validation errors occur.
+        A builder object with chainable methods:
+
+        - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
+        - `namespace(namespace)`: Sets the namespace (optional). String with segments separated by '/'.
+        - `name(name)`: Sets the package name (required).
+        - `version(version)`: Sets the package version (optional).
+        - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
+          Key must start with ASCII letter and contain only lowercase letters,
+          numbers, '.', '-', '_'.
+        - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
+        - `build()`: Constructs the final PURL string. Fails on validation errors.
     """
 
     fields = {}

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -90,15 +90,16 @@ def _builder():
 
     Returns:
         A builder object with chainable methods:
-            - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
-            - `namespace(namespace)`: Sets the namespace (optional). String or list of strings.
-            - `name(name)`: Sets the package name (required).
-            - `version(version)`: Sets the package version (optional).
-            - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
-                Key must start with ASCII letter and contain only lowercase letters,
-                numbers, '.', '-', '_'.
-            - `subpath(subpath)`: Sets the subpath (optional). List of path segments.
-            - `build()`: Constructs the final PURL string. Fails on validation errors.
+
+        - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
+        - `namespace(namespace)`: Sets the namespace (optional). String or list of strings.
+        - `name(name)`: Sets the package name (required).
+        - `version(version)`: Sets the package version (optional).
+        - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
+          Key must start with ASCII letter and contain only lowercase letters,
+          numbers, '.', '-', '_'.
+        - `subpath(subpath)`: Sets the subpath (optional). List of path segments.
+        - `build()`: Constructs the final PURL string. Fails on validation errors.
     """
     return builder()
 

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -41,7 +41,68 @@ def _bazel(name, version):
 
     return builder().type("bazel").name(name).version(version).build()
 
+def _builder():
+    """Creates a fluent builder for constructing Package URLs (PURLs).
+
+    The builder provides a chainable interface for constructing PURLs according to
+    the [Package URL specification](https://github.com/package-url/purl-spec).
+
+    The `type` and `name` fields are required. All components are validated and
+    normalized according to the PURL spec. Components are automatically percent-encoded
+    where necessary, and qualifiers are sorted lexicographically in the output.
+
+    Example - Simple PURL:
+
+        load("@package_metadata//purl:purl.bzl", "purl")
+
+        my_purl = (purl.builder()
+            .type("npm")
+            .name("lodash")
+            .version("4.17.21")
+            .build())
+        # Result: pkg:npm/lodash@4.17.21
+
+    Example - PURL with namespace, qualifiers, and subpath:
+
+        load("@package_metadata//purl:purl.bzl", "purl")
+
+        my_purl = (purl.builder()
+            .type("maven")
+            .namespace("org.apache.commons")
+            .name("commons-lang3")
+            .version("3.12.0")
+            .add_qualifier("classifier", "sources")
+            .add_qualifier("type", "jar")
+            .subpath(["src", "main"])
+            .build())
+        # Result: pkg:maven/org.apache.commons/commons-lang3@3.12.0?classifier=sources&type=jar#src/main
+
+    Example - Multi-segment namespaces:
+
+        load("@package_metadata//purl:purl.bzl", "purl")
+
+        my_purl = (purl.builder()
+            .type("golang")
+            .namespace(["github.com", "user", "project"])
+            .name("package")
+            .build())
+        # Result: pkg:golang/github.com/user/project/package
+
+    Returns:
+        A builder object with chainable methods:
+            - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
+            - `namespace(namespace)`: Sets the namespace (optional). String or list of strings.
+            - `name(name)`: Sets the package name (required).
+            - `version(version)`: Sets the package version (optional).
+            - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
+                Key must start with ASCII letter and contain only lowercase letters,
+                numbers, '.', '-', '_'.
+            - `subpath(subpath)`: Sets the subpath (optional). List of path segments.
+            - `build()`: Constructs the final PURL string. Fails on validation errors.
+    """
+    return builder()
+
 purl = struct(
     bazel = _bazel,
-    builder = builder,
+    builder = _builder,
 )

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -77,13 +77,13 @@ def _builder():
             .build())
         # Result: pkg:maven/org.apache.commons/commons-lang3@3.12.0?classifier=sources&type=jar#src/main
 
-    Example - Multi-segment namespaces:
+    Example - Multi-segment namespace:
 
         load("@package_metadata//purl:purl.bzl", "purl")
 
         my_purl = (purl.builder()
             .type("golang")
-            .namespace(["github.com", "user", "project"])
+            .namespace("github.com/user/project")
             .name("package")
             .build())
         # Result: pkg:golang/github.com/user/project/package
@@ -92,13 +92,13 @@ def _builder():
         A builder object with chainable methods:
 
         - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
-        - `namespace(namespace)`: Sets the namespace (optional). String or list of strings.
+        - `namespace(namespace)`: Sets the namespace (optional). String with segments separated by '/'.
         - `name(name)`: Sets the package name (required).
         - `version(version)`: Sets the package version (optional).
         - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
           Key must start with ASCII letter and contain only lowercase letters,
           numbers, '.', '-', '_'.
-        - `subpath(subpath)`: Sets the subpath (optional). List of path segments.
+        - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
         - `build()`: Constructs the final PURL string. Fails on validation errors.
     """
     return builder()

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -41,70 +41,7 @@ def _bazel(name, version):
 
     return builder().type("bazel").name(name).version(version).build()
 
-def _builder():
-    """Creates a fluent builder for constructing Package URLs (PURLs).
-
-    The builder provides a chainable interface for constructing PURLs according to
-    the [Package URL specification](https://github.com/package-url/purl-spec).
-
-    The `type` and `name` fields are required. All components are validated and
-    normalized according to the PURL spec. Components are automatically percent-encoded
-    where necessary, and qualifiers are sorted lexicographically in the output.
-
-    Example - Simple PURL:
-
-        load("@package_metadata//purl:purl.bzl", "purl")
-
-        my_purl = (purl.builder()
-            .type("npm")
-            .name("foobar")
-            .version("12.3.1")
-            .build())
-        # Result: pkg:npm/foobar@12.3.1
-
-    Example - Maven with namespace and qualifiers:
-
-        load("@package_metadata//purl:purl.bzl", "purl")
-
-        my_purl = (purl.builder()
-            .type("maven")
-            .namespace("org.apache.xmlgraphics")
-            .name("batik-anim")
-            .version("1.9.1")
-            .add_qualifier("classifier", "sources")
-            .add_qualifier("repository_url", "https://repo.spring.io/release")
-            .build())
-        # Result: pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=https%3A%2F%2Frepo.spring.io%2Frelease
-
-    Example - Golang with namespace and subpath:
-
-        load("@package_metadata//purl:purl.bzl", "purl")
-
-        my_purl = (purl.builder()
-            .type("golang")
-            .namespace("google.golang.org")
-            .name("genproto")
-            .version("abcdedf")
-            .subpath("googleapis/api/annotations")
-            .build())
-        # Result: pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations
-
-    Returns:
-        A builder object with chainable methods:
-
-        - `type(type_name)`: Sets the package type (required). Must be lowercase ASCII.
-        - `namespace(namespace)`: Sets the namespace (optional). String with segments separated by '/'.
-        - `name(name)`: Sets the package name (required).
-        - `version(version)`: Sets the package version (optional).
-        - `add_qualifier(name, value)`: Adds a qualifier (optional, repeatable).
-          Key must start with ASCII letter and contain only lowercase letters,
-          numbers, '.', '-', '_'.
-        - `subpath(subpath)`: Sets the subpath (optional). String with segments separated by '/'.
-        - `build()`: Constructs the final PURL string. Fails on validation errors.
-    """
-    return builder()
-
 purl = struct(
+    builder = builder,
     bazel = _bazel,
-    builder = _builder,
 )

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -57,36 +57,37 @@ def _builder():
 
         my_purl = (purl.builder()
             .type("npm")
-            .name("lodash")
-            .version("4.17.21")
+            .name("foobar")
+            .version("12.3.1")
             .build())
-        # Result: pkg:npm/lodash@4.17.21
+        # Result: pkg:npm/foobar@12.3.1
 
-    Example - PURL with namespace, qualifiers, and subpath:
+    Example - Maven with namespace and qualifiers:
 
         load("@package_metadata//purl:purl.bzl", "purl")
 
         my_purl = (purl.builder()
             .type("maven")
-            .namespace("org.apache.commons")
-            .name("commons-lang3")
-            .version("3.12.0")
+            .namespace("org.apache.xmlgraphics")
+            .name("batik-anim")
+            .version("1.9.1")
             .add_qualifier("classifier", "sources")
-            .add_qualifier("type", "jar")
-            .subpath(["src", "main"])
+            .add_qualifier("repository_url", "https://repo.spring.io/release")
             .build())
-        # Result: pkg:maven/org.apache.commons/commons-lang3@3.12.0?classifier=sources&type=jar#src/main
+        # Result: pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=https%3A%2F%2Frepo.spring.io%2Frelease
 
-    Example - Multi-segment namespace:
+    Example - Golang with namespace and subpath:
 
         load("@package_metadata//purl:purl.bzl", "purl")
 
         my_purl = (purl.builder()
             .type("golang")
-            .namespace("github.com/user/project")
-            .name("package")
+            .namespace("google.golang.org")
+            .name("genproto")
+            .version("abcdedf")
+            .subpath("googleapis/api/annotations")
             .build())
-        # Result: pkg:golang/github.com/user/project/package
+        # Result: pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations
 
     Returns:
         A builder object with chainable methods:


### PR DESCRIPTION
Add comprehensive documentation for the purl.builder() function including:
- Detailed docstrings in builder.bzl and purl.bzl
- Three practical usage examples (simple PURL, advanced with all components, multi-segment namespaces)
- Complete method reference with parameter descriptions and validation rules
- Notes on automatic normalization and percent-encoding behavior

The documentation is now Stardoc-compatible and all tests pass.