### PR TITLE
Fix release script (use $TAG instead of invalid head reference).

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -31,7 +31,7 @@ echo MODULE=$MODULE
 
 # NB: configuration for 'git archive' is in /.gitattributes
 echo git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
-git archive --format=tar --prefix=${PREFIX}/ head | gzip > $ARCHIVE
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat << EOF


### PR DESCRIPTION
Commit https://github.com/bazel-contrib/supply-chain/commit/9ffb9e26 accidentally changed the tag reference to head.