### PR TITLE
set file extension according to output format

### DIFF
--- a/tools/sbom/spdx.bzl
+++ b/tools/sbom/spdx.bzl
@@ -1,7 +1,11 @@
 load("providers.bzl", "SbomInfo")
 
 def _spdx_impl(ctx):
-    out_path = ctx.attr.out.name if ctx.attr.out != None else "%s.txt" % ctx.attr.name
+    out_path = ctx.attr.out.name if ctx.attr.out != None else \
+        "%s.txt" % ctx.attr.name if ctx.attr.format == "tag-value" else \
+        "%s.json" % ctx.attr.name if ctx.attr.format == "json" else \
+        "%s.yaml" % ctx.attr.name if ctx.attr.format == "yaml"
+
     out = ctx.actions.declare_file(out_path)
     inputs = depset(
         [],


### PR DESCRIPTION
This sets the default file extension according to it's output format making it what tools and people expect it to match the content of the file