### PR TITLE
[metadata] Add comprehensive documentation to common utilities

### DIFF
--- a/docs/metadata/common/BUILD
+++ b/docs/metadata/common/BUILD
@@ -1,0 +1,23 @@
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
+
+[
+    [
+        stardoc(
+            name = file,
+            out = "{}.generated.md".format(file),
+            input = "@package_metadata//common:{}.bzl".format(file),
+            deps = [
+                "@package_metadata//common:srcs",
+            ],
+        ),
+        diff_test(
+            name = "{}_test".format(file),
+            file1 = ":{}".format(file),
+            file2 = "{}.md".format(file),
+        ),
+    ]
+    for file in [
+        "common",
+    ]
+]

--- a/docs/metadata/common/common.md
+++ b/docs/metadata/common/common.md
@@ -1,0 +1,130 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Common utilities for creating package and target metadata.
+
+This module provides helper functions for creating metadata about Bazel packages
+and targets in a structured format. These utilities are typically used within
+rule implementations to generate metadata providers.
+
+## Usage
+
+Load this module to access helper functions for creating metadata:
+
+```starlark
+load("@rules_supplychain//metadata/common:common.bzl", "package_metadata_common")
+
+def _my_rule_impl(ctx):
+    # Create package metadata
+    pkg_info = package_metadata_common.create_package_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        purl = "pkg:example/my-package@1.0.0",
+        attributes = [attr[PackageAttributeInfo] for attr in ctx.attr.attributes],
+    )
+
+    # Create target metadata
+    target_info = package_metadata_common.create_target_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        package_metadata = [dep[PackageMetadataInfo] for dep in ctx.attr.deps],
+    )
+
+    return [pkg_info, target_info]
+```
+
+<a id="package_metadata_common.create_package_metadata"></a>
+
+## package_metadata_common.create_package_metadata
+
+<pre>
+load("@package_metadata//common:common.bzl", "package_metadata_common")
+
+package_metadata_common.create_package_metadata(*, <a href="#package_metadata_common.create_package_metadata-actions">actions</a>, <a href="#package_metadata_common.create_package_metadata-label">label</a>, <a href="#package_metadata_common.create_package_metadata-purl">purl</a>, <a href="#package_metadata_common.create_package_metadata-attributes">attributes</a>)
+</pre>
+
+Creates a PackageMetadataInfo provider with JSON metadata.
+
+This function generates a JSON file containing metadata about a Bazel package,
+including its PURL (Package URL), label, and attributes. The metadata is
+structured for consumption by supply chain analysis tools.
+
+**Example:**
+
+```starlark
+def _my_rule_impl(ctx):
+    info = create_package_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        purl = "pkg:npm/my-package@1.0.0",
+        attributes = [a[PackageAttributeInfo] for a in ctx.attr.attributes],
+    )
+    return [info]
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="package_metadata_common.create_package_metadata-actions"></a>actions |  The [actions](https://bazel.build/rules/lib/builtins/actions) object from the rule context, used to declare and write files.   |  none |
+| <a id="package_metadata_common.create_package_metadata-label"></a>label |  The [Label](https://bazel.build/rules/lib/builtins/Label) of the target being processed.   |  none |
+| <a id="package_metadata_common.create_package_metadata-purl"></a>purl |  A string containing the [PURL](https://github.com/package-url/purl-spec) uniquely identifying this package (e.g., "pkg:npm/lodash@4.17.21").   |  none |
+| <a id="package_metadata_common.create_package_metadata-attributes"></a>attributes |  A list of [PackageAttributeInfo](//providers:package_attribute_info.bzl) providers representing package attributes (e.g., source location, license). Defaults to an empty list.   |  `[]` |
+
+**RETURNS**
+
+A [PackageMetadataInfo](//providers:package_metadata_info.bzl) provider
+  containing the generated metadata file and transitive files from all
+  attributes.
+
+
+<a id="package_metadata_common.create_target_metadata"></a>
+
+## package_metadata_common.create_target_metadata
+
+<pre>
+load("@package_metadata//common:common.bzl", "package_metadata_common")
+
+package_metadata_common.create_target_metadata(*, <a href="#package_metadata_common.create_target_metadata-actions">actions</a>, <a href="#package_metadata_common.create_target_metadata-label">label</a>, <a href="#package_metadata_common.create_target_metadata-package_metadata">package_metadata</a>)
+</pre>
+
+Creates a TargetMetadataInfo provider with JSON metadata.
+
+This function generates a JSON file containing metadata about a Bazel target,
+including its label and references to package metadata from its dependencies.
+The metadata is structured for consumption by supply chain analysis tools.
+
+**Example:**
+
+```starlark
+def _my_rule_impl(ctx):
+    info = create_target_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        package_metadata = [
+            dep[PackageMetadataInfo]
+            for dep in ctx.attr.deps
+            if PackageMetadataInfo in dep
+        ],
+    )
+    return [info]
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="package_metadata_common.create_target_metadata-actions"></a>actions |  The [actions](https://bazel.build/rules/lib/builtins/actions) object from the rule context, used to declare and write files.   |  none |
+| <a id="package_metadata_common.create_target_metadata-label"></a>label |  The [Label](https://bazel.build/rules/lib/builtins/Label) of the target being processed.   |  none |
+| <a id="package_metadata_common.create_target_metadata-package_metadata"></a>package_metadata |  A list of [PackageMetadataInfo](//providers:package_metadata_info.bzl) providers directly attached to the target being processed Defaults to an empty list.   |  `[]` |
+
+**RETURNS**
+
+A [TargetMetadataInfo](//providers:target_metadata_info.bzl) provider
+  containing the generated metadata file and transitive files from all
+  package metadata.
+
+

--- a/docs/metadata/defs.md
+++ b/docs/metadata/defs.md
@@ -136,6 +136,102 @@ package_metadata(*, <a href="#package_metadata-name">name</a>, <a href="#package
 | <a id="package_metadata-tags"></a>tags |  <p align="center"> - </p>   |  `None` |
 
 
+<a id="package_metadata_common.create_package_metadata"></a>
+
+## package_metadata_common.create_package_metadata
+
+<pre>
+load("@package_metadata//:defs.bzl", "package_metadata_common")
+
+package_metadata_common.create_package_metadata(*, <a href="#package_metadata_common.create_package_metadata-actions">actions</a>, <a href="#package_metadata_common.create_package_metadata-label">label</a>, <a href="#package_metadata_common.create_package_metadata-purl">purl</a>, <a href="#package_metadata_common.create_package_metadata-attributes">attributes</a>)
+</pre>
+
+Creates a PackageMetadataInfo provider with JSON metadata.
+
+This function generates a JSON file containing metadata about a Bazel package,
+including its PURL (Package URL), label, and attributes. The metadata is
+structured for consumption by supply chain analysis tools.
+
+**Example:**
+
+```starlark
+def _my_rule_impl(ctx):
+    info = create_package_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        purl = "pkg:npm/my-package@1.0.0",
+        attributes = [a[PackageAttributeInfo] for a in ctx.attr.attributes],
+    )
+    return [info]
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="package_metadata_common.create_package_metadata-actions"></a>actions |  The [actions](https://bazel.build/rules/lib/builtins/actions) object from the rule context, used to declare and write files.   |  none |
+| <a id="package_metadata_common.create_package_metadata-label"></a>label |  The [Label](https://bazel.build/rules/lib/builtins/Label) of the target being processed.   |  none |
+| <a id="package_metadata_common.create_package_metadata-purl"></a>purl |  A string containing the [PURL](https://github.com/package-url/purl-spec) uniquely identifying this package (e.g., "pkg:npm/lodash@4.17.21").   |  none |
+| <a id="package_metadata_common.create_package_metadata-attributes"></a>attributes |  A list of [PackageAttributeInfo](//providers:package_attribute_info.bzl) providers representing package attributes (e.g., source location, license). Defaults to an empty list.   |  `[]` |
+
+**RETURNS**
+
+A [PackageMetadataInfo](//providers:package_metadata_info.bzl) provider
+  containing the generated metadata file and transitive files from all
+  attributes.
+
+
+<a id="package_metadata_common.create_target_metadata"></a>
+
+## package_metadata_common.create_target_metadata
+
+<pre>
+load("@package_metadata//:defs.bzl", "package_metadata_common")
+
+package_metadata_common.create_target_metadata(*, <a href="#package_metadata_common.create_target_metadata-actions">actions</a>, <a href="#package_metadata_common.create_target_metadata-label">label</a>, <a href="#package_metadata_common.create_target_metadata-package_metadata">package_metadata</a>)
+</pre>
+
+Creates a TargetMetadataInfo provider with JSON metadata.
+
+This function generates a JSON file containing metadata about a Bazel target,
+including its label and references to package metadata from its dependencies.
+The metadata is structured for consumption by supply chain analysis tools.
+
+**Example:**
+
+```starlark
+def _my_rule_impl(ctx):
+    info = create_target_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        package_metadata = [
+            dep[PackageMetadataInfo]
+            for dep in ctx.attr.deps
+            if PackageMetadataInfo in dep
+        ],
+    )
+    return [info]
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="package_metadata_common.create_target_metadata-actions"></a>actions |  The [actions](https://bazel.build/rules/lib/builtins/actions) object from the rule context, used to declare and write files.   |  none |
+| <a id="package_metadata_common.create_target_metadata-label"></a>label |  The [Label](https://bazel.build/rules/lib/builtins/Label) of the target being processed.   |  none |
+| <a id="package_metadata_common.create_target_metadata-package_metadata"></a>package_metadata |  A list of [PackageMetadataInfo](//providers:package_metadata_info.bzl) providers directly attached to the target being processed Defaults to an empty list.   |  `[]` |
+
+**RETURNS**
+
+A [TargetMetadataInfo](//providers:target_metadata_info.bzl) provider
+  containing the generated metadata file and transitive files from all
+  package metadata.
+
+
 <a id="purl.bazel"></a>
 
 ## purl.bazel

--- a/metadata/BUILD
+++ b/metadata/BUILD
@@ -14,6 +14,7 @@ filegroup(
     srcs = [
         "defs.bzl",
     ] + [
+        "//common:srcs",
         "//licenses:srcs",
         "//providers:srcs",
         "//purl:srcs",

--- a/metadata/common/BUILD
+++ b/metadata/common/BUILD
@@ -1,6 +1,6 @@
 exports_files(
     [
-        "package_metadata.bzl",
+        "common.bzl",
     ],
     visibility = ["//visibility:public"],
 )
@@ -8,9 +8,9 @@ exports_files(
 filegroup(
     name = "srcs",
     srcs = [
-        "package_metadata.bzl",
+        "common.bzl",
     ] + [
-        "//common:srcs",
+        "//common/private:srcs",
         "//providers:srcs",
     ],
     visibility = ["//visibility:public"],

--- a/metadata/common/common.bzl
+++ b/metadata/common/common.bzl
@@ -1,0 +1,42 @@
+"""Common utilities for creating package and target metadata.
+
+This module provides helper functions for creating metadata about Bazel packages
+and targets in a structured format. These utilities are typically used within
+rule implementations to generate metadata providers.
+
+## Usage
+
+Load this module to access helper functions for creating metadata:
+
+```starlark
+load("@rules_supplychain//metadata/common:common.bzl", "package_metadata_common")
+
+def _my_rule_impl(ctx):
+    # Create package metadata
+    pkg_info = package_metadata_common.create_package_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        purl = "pkg:example/my-package@1.0.0",
+        attributes = [attr[PackageAttributeInfo] for attr in ctx.attr.attributes],
+    )
+
+    # Create target metadata
+    target_info = package_metadata_common.create_target_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        package_metadata = [dep[PackageMetadataInfo] for dep in ctx.attr.deps],
+    )
+
+    return [pkg_info, target_info]
+```
+"""
+
+load("//common/private:create_package_metadata.bzl", "create_package_metadata")
+load("//common/private:create_target_metadata.bzl", "create_target_metadata")
+
+visibility("public")
+
+package_metadata_common = struct(
+    create_package_metadata = create_package_metadata,
+    create_target_metadata = create_target_metadata,
+)

--- a/metadata/common/private/BUILD
+++ b/metadata/common/private/BUILD
@@ -1,0 +1,20 @@
+exports_files(
+    [
+        "create_package_metadata.bzl",
+        "create_target_metadata.bzl",
+    ],
+    visibility = [
+        "//common:__subpackages__",
+    ],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = [
+        "create_package_metadata.bzl",
+        "create_target_metadata.bzl",
+    ],
+    visibility = [
+        "//common:__subpackages__",
+    ],
+)

--- a/metadata/common/private/create_package_metadata.bzl
+++ b/metadata/common/private/create_package_metadata.bzl
@@ -1,0 +1,59 @@
+"""Utilities for creating package metadata."""
+
+load("//providers:package_metadata_info.bzl", "PackageMetadataInfo")
+
+visibility([
+    "//common/...",
+])
+
+def create_package_metadata(*, actions, label, purl, attributes = []):
+    """Creates a PackageMetadataInfo provider with JSON metadata.
+
+    This function generates a JSON file containing metadata about a Bazel package,
+    including its PURL (Package URL), label, and attributes. The metadata is
+    structured for consumption by supply chain analysis tools.
+
+    **Example:**
+
+    ```starlark
+    def _my_rule_impl(ctx):
+        info = create_package_metadata(
+            actions = ctx.actions,
+            label = ctx.label,
+            purl = "pkg:npm/my-package@1.0.0",
+            attributes = [a[PackageAttributeInfo] for a in ctx.attr.attributes],
+        )
+        return [info]
+    ```
+
+    Args:
+        actions: The [actions](https://bazel.build/rules/lib/builtins/actions)
+            object from the rule context, used to declare and write files.
+        label: The [Label](https://bazel.build/rules/lib/builtins/Label) of the
+            target being processed.
+        purl: A string containing the [PURL](https://github.com/package-url/purl-spec)
+            uniquely identifying this package (e.g., "pkg:npm/lodash@4.17.21").
+        attributes: A list of [PackageAttributeInfo](//providers:package_attribute_info.bzl)
+            providers representing package attributes (e.g., source location, license).
+            Defaults to an empty list.
+
+    Returns:
+        A [PackageMetadataInfo](//providers:package_metadata_info.bzl) provider
+        containing the generated metadata file and transitive files from all
+        attributes.
+    """
+
+    metadata = actions.declare_file("{}.package-metadata.json".format(label.name))
+    actions.write(
+        output = metadata,
+        content = json.encode({
+            "attributes": {a.kind: a.attributes.path for a in attributes},
+            "label": str(label),
+            "purl": purl,
+        }),
+    )
+
+    return PackageMetadataInfo(
+        metadata = metadata,
+        files = [a.files for a in attributes],
+    )

--- a/metadata/common/private/create_target_metadata.bzl
+++ b/metadata/common/private/create_target_metadata.bzl
@@ -1,0 +1,58 @@
+"""Utilities for creating target metadata."""
+
+load("//providers:target_metadata_info.bzl", "TargetMetadataInfo")
+
+visibility([
+    "//common/...",
+])
+
+def create_target_metadata(*, actions, label, package_metadata = []):
+    """Creates a TargetMetadataInfo provider with JSON metadata.
+
+    This function generates a JSON file containing metadata about a Bazel target,
+    including its label and references to package metadata from its dependencies.
+    The metadata is structured for consumption by supply chain analysis tools.
+
+    **Example:**
+
+    ```starlark
+    def _my_rule_impl(ctx):
+        info = create_target_metadata(
+            actions = ctx.actions,
+            label = ctx.label,
+            package_metadata = [
+                dep[PackageMetadataInfo]
+                for dep in ctx.attr.deps
+                if PackageMetadataInfo in dep
+            ],
+        )
+        return [info]
+    ```
+
+    Args:
+        actions: The [actions](https://bazel.build/rules/lib/builtins/actions)
+            object from the rule context, used to declare and write files.
+        label: The [Label](https://bazel.build/rules/lib/builtins/Label) of the
+            target being processed.
+        package_metadata: A list of [PackageMetadataInfo](//providers:package_metadata_info.bzl)
+            providers directly attached to the target being processed Defaults
+            to an empty list.
+
+    Returns:
+        A [TargetMetadataInfo](//providers:target_metadata_info.bzl) provider
+        containing the generated metadata file and transitive files from all
+        package metadata.
+    """
+    metadata = actions.declare_file("{}.target-metadata.json".format(label.name))
+    actions.write(
+        output = metadata,
+        content = json.encode({
+            "label": str(label),
+            "package_metadata": [p.metadata.path for p in package_metadata],
+        }),
+    )
+
+    return TargetMetadataInfo(
+        metadata = metadata,
+        files = [a.files for a in package_metadata],
+    )

--- a/metadata/defs.bzl
+++ b/metadata/defs.bzl
@@ -1,5 +1,6 @@
 """Public API of `@package_metadata`."""
 
+load("//common:common.bzl", _package_metadata_common = "package_metadata_common")
 load("//providers:package_attribute_info.bzl", _PackageAttributeInfo = "PackageAttributeInfo")
 load("//providers:package_metadata_info.bzl", _PackageMetadataInfo = "PackageMetadataInfo")
 load("//providers:package_metadata_override_info.bzl", _PackageMetadataOverrideInfo = "PackageMetadataOverrideInfo")
@@ -21,4 +22,5 @@ TargetMetadataInfo = _TargetMetadataInfo
 package_metadata = _package_metadata
 
 # Utils
+package_metadata_common = _package_metadata_common
 purl = _purl

--- a/metadata/rules/package_metadata.bzl
+++ b/metadata/rules/package_metadata.bzl
@@ -1,35 +1,26 @@
 """Declares rule `package_metadata`."""
 
+load("//common:common.bzl", "package_metadata_common")
 load("//providers:package_attribute_info.bzl", "PackageAttributeInfo")
 load("//providers:package_metadata_info.bzl", "PackageMetadataInfo")
 
 visibility("public")
 
 def _package_metadata_impl(ctx):
-    attributes = [a[PackageAttributeInfo] for a in ctx.attr.attributes]
-
-    metadata = ctx.actions.declare_file("{}.package-metadata.json".format(ctx.attr.name))
-
-    ctx.actions.write(
-        output = metadata,
-        content = json.encode({
-            "attributes": {a.kind: a.attributes.path for a in attributes},
-            "label": str(ctx.label),
-            "purl": ctx.attr.purl,
-        }),
+    info = package_metadata_common.create_package_metadata(
+        actions = ctx.actions,
+        label = ctx.label,
+        purl = ctx.attr.purl,
+        attributes = [a[PackageAttributeInfo] for a in ctx.attr.attributes],
     )
-
     return [
+        info,
         DefaultInfo(
             files = depset(
                 direct = [
-                    metadata,
+                    info.metadata,
                 ],
             ),
-        ),
-        PackageMetadataInfo(
-            metadata = metadata,
-            files = [a.files for a in attributes],
         ),
     ]
 


### PR DESCRIPTION
Add detailed module and function documentation to metadata/common:
- Document common.bzl module with usage examples
- Add detailed docstrings to create_package_metadata() with parameter descriptions, return values, and examples
- Add detailed docstrings to create_target_metadata() with parameter descriptions, return values, and examples
- Generate and update Stardoc documentation for common module

The documentation follows Starlark conventions and includes:
- Module-level overview and usage examples
- Function descriptions explaining purpose and behavior
- Parameter documentation with types and descriptions
- Return value documentation
- Practical code examples for each function