### PR TITLE
Add registry parameter for bazel purl

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [this page](roadmap.md).
 
 ## Background reading:
 
-These is for learning about the problem space, and our approach to solutions. Concrete specifications will always appear in checked in code rather than documents.
+These are for learning about the problem space, and our approach to solutions. Concrete specifications will always appear in checked in code rather than documents.
 - [License Checking with Bazel](https://docs.google.com/document/d/1uwBuhAoBNrw8tmFs-NxlssI6VRolidGYdYqagLqHWt8/edit#).
 - [OSS Licenses and Bazel Dependency Management](https://docs.google.com/document/d/1oY53dQ0pOPEbEvIvQ3TvHcFKClkimlF9AtN89EPiVJU/edit#)
 - [Adding OSS license declarations to Bazel](https://docs.google.com/document/d/1XszGbpMYNHk_FGRxKJ9IXW10KxMPdQpF5wWbZFpA4C8/edit#heading=h.5mcn15i0e1ch)

--- a/docs/metadata/defs.md
+++ b/docs/metadata/defs.md
@@ -121,7 +121,7 @@ package_metadata(*, <a href="#package_metadata-name">name</a>, <a href="#package
 <pre>
 load("@package_metadata//:defs.bzl", "purl")
 
-purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>)
+purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>, <a href="#purl.bazel-registry">registry</a>)
 </pre>
 
 Defines a `purl` for a Bazel module.
@@ -154,6 +154,7 @@ package_metadata(
 | :------------- | :------------- | :------------- |
 | <a id="purl.bazel-name"></a>name |  The name of the Bazel module. Typically [module_name()](https://bazel.build/rules/lib/globals/build#module_name).   |  none |
 | <a id="purl.bazel-version"></a>version |  The version of the Bazel module. Typically [module_version()](https://bazel.build/rules/lib/globals/build#module_version). May be empty or `None`.   |  none |
+| <a id="purl.bazel-registry"></a>registry |  The URL of the registry that hosts the Bazel module. Defaults to https://bcr.bazel.build.   |  `"https://bcr.bazel.build"` |
 
 **RETURNS**
 

--- a/docs/metadata/purl/purl.md
+++ b/docs/metadata/purl/purl.md
@@ -9,7 +9,7 @@ Module defining urils for [purl](https://github.com/package-url/purl-spec)s.
 <pre>
 load("@package_metadata//purl:purl.bzl", "purl")
 
-purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>)
+purl.bazel(<a href="#purl.bazel-name">name</a>, <a href="#purl.bazel-version">version</a>, <a href="#purl.bazel-registry">registry</a>)
 </pre>
 
 Defines a `purl` for a Bazel module.
@@ -42,6 +42,7 @@ package_metadata(
 | :------------- | :------------- | :------------- |
 | <a id="purl.bazel-name"></a>name |  The name of the Bazel module. Typically [module_name()](https://bazel.build/rules/lib/globals/build#module_name).   |  none |
 | <a id="purl.bazel-version"></a>version |  The version of the Bazel module. Typically [module_version()](https://bazel.build/rules/lib/globals/build#module_version). May be empty or `None`.   |  none |
+| <a id="purl.bazel-registry"></a>registry |  The URL of the registry that hosts the Bazel module. Defaults to https://bcr.bazel.build.   |  `"https://bcr.bazel.build"` |
 
 **RETURNS**
 

--- a/metadata/purl/purl.bzl
+++ b/metadata/purl/purl.bzl
@@ -5,7 +5,9 @@ load("//purl/private:parser.bzl", "parse")
 
 visibility("public")
 
-def _bazel(name, version):
+_DEFAULT_REGISTRY = "https://bcr.bazel.build"
+
+def _bazel(name, version, registry = _DEFAULT_REGISTRY):
     """Defines a `purl` for a Bazel module.
 
     This is typically used to construct `purl` for `package_metadata` targets in
@@ -34,13 +36,20 @@ def _bazel(name, version):
         version (str): The version of the Bazel module. Typically
                        [module_version()](https://bazel.build/rules/lib/globals/build#module_version).
                        May be empty or `None`.
+        registry (str): The URL of the registry that hosts the Bazel module. Defaults to
+                         https://bcr.bazel.build.
 
     Returns:
         The `purl` for the Bazel module (e.g. `pkg:bazel/foo` or
         `pkg:bazel/bar@1.2.3`).
     """
 
-    return builder().type("bazel").name(name).version(version).build()
+    bazel_purl = builder().type("bazel").name(name).version(version)
+
+    if registry != _DEFAULT_REGISTRY:
+        bazel_purl.add_qualifier("repository_url", registry)
+
+    return bazel_purl.build()
 
 purl = struct(
     builder = builder,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,6 +1,7 @@
 load("@package_metadata//licenses/rules:license.bzl", "license")
 load("@package_metadata//purl:purl.bzl", "purl")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
+load("//:purl_test.bzl", "purl_bazel_registry_test")
 
 package_metadata(
     name = "package_metadata",
@@ -18,4 +19,8 @@ license(
     name = "license",
     kind = "@package_metadata//licenses/spdx:Apache-2.0",
     text = "LICENSE",
+)
+
+purl_bazel_registry_test(
+    name = "purl_bazel_registry_test",
 )

--- a/tests/purl_test.bzl
+++ b/tests/purl_test.bzl
@@ -1,0 +1,73 @@
+"""Tests for public PURL helpers."""
+
+load("@package_metadata//purl:purl.bzl", "purl")
+
+_bash_executable = """
+#!/usr/bin/env bash
+
+echo '{message}'
+exit {status}
+""".strip()
+
+_bat_executable = """
+echo '{message}'
+exit /b {status}
+""".strip()
+
+def _expect_equals(description, actual, expected, failures):
+    if actual != expected:
+        failures.append({
+            "actual": actual,
+            "description": description,
+            "expected": expected,
+        })
+
+def _purl_bazel_registry_test_impl(ctx):
+    failures = []
+
+    _expect_equals(
+        "default registry is omitted",
+        purl.bazel("rules_java", "7.8.0"),
+        "pkg:bazel/rules_java@7.8.0",
+        failures,
+    )
+    _expect_equals(
+        "custom registry is emitted as repository_url",
+        purl.bazel(
+            "rules_java",
+            "7.8.0",
+            registry = "https://example.org/bazel-registry",
+        ),
+        "pkg:bazel/rules_java@7.8.0?repository_url=https:%2F%2Fexample.org%2Fbazel-registry",
+        failures,
+    )
+
+    content = _bash_executable if (ctx.configuration.host_path_separator == ":") else _bat_executable
+
+    # Unix does not care about the file extension, so always use `.bat` so it
+    # also works on Windows.
+    executable = ctx.actions.declare_file("{}.bat".format(ctx.attr.name))
+    ctx.actions.write(
+        output = executable,
+        content = content.format(
+            message = json.encode_indent(failures),
+            status = 1 if len(failures) else 0,
+        ),
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset(
+                direct = [
+                    executable,
+                ],
+            ),
+            executable = executable,
+        ),
+    ]
+
+purl_bazel_registry_test = rule(
+    implementation = _purl_bazel_registry_test_impl,
+    test = True,
+)


### PR DESCRIPTION
This adds back https://github.com/bazel-contrib/supply-chain/pull/133 that was originally added as part of another change that got reverted.

It also adds a test