### PR TITLE
add missing BCR templates for supply_chain_tools

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -3,5 +3,13 @@
 This directory contains configuration files to automatically publish releases
 (`"git tags"`) to the [Bazel Central Registry](https://registry.bazel.build).
 
+Things to note:
+- There is 1 folder per sub-release from the project
+- The folder is named by the **published** release (and BCR) name
+- The presubmit job uses the published name because it has to match
+  what an end user would see.
+- The source template inside each uses the source tree **folder** name
+  because it must provide the correct strip_prefix based on the tarball.
+
 See <https://github.com/bazel-contrib/publish-to-bcr/blob/main/templates/README.md>
 for authoritative documentation about these files.

--- a/.bcr/supply_chain_tools/metadata.template.json
+++ b/.bcr/supply_chain_tools/metadata.template.json
@@ -1,0 +1,28 @@
+{
+  "homepage": "https://github.com/bazel-contrib/supply-chain",
+  "maintainers": [
+    {
+      "email": "antonio@engflow.com",
+      "github": "TheGrizzlyDev",
+      "name": "Antonio Di Stefano"
+    },
+    {
+      "email": "fwe@google.com",
+      "github": "fweikert",
+      "name": "Florian Weikert"
+    },
+    {
+      "email": "tony.aiuto@datadoghq.com",
+      "github": "aiuto",
+      "name": "Tony Aiuto"
+    },
+    {
+      "email": "yannic@engflow.com",
+      "github": "Yannic",
+      "name": "Yannic Bonenberger"
+    }
+  ],
+  "repository": ["github:bazel-contrib/supply-chain"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/supply_chain_tools/presubmit.yml
+++ b/.bcr/supply_chain_tools/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@supply_chain_tools//...'

--- a/.bcr/supply_chain_tools/presubmit.yml
+++ b/.bcr/supply_chain_tools/presubmit.yml
@@ -5,9 +5,9 @@ matrix:
   - macos
   - windows
   bazel:
-  - 8.x
   - 7.x
-  - 6.x
+  - 8.x
+  - 9.x
 tasks:
   verify_targets:
     name: Verify build targets

--- a/.bcr/supply_chain_tools/source.template.json
+++ b/.bcr/supply_chain_tools/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "**leave this alone**",
+  "strip_prefix": "{TAG}/metadata",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{TAG}.tar.gz"
+}

--- a/.bcr/supply_chain_tools/source.template.json
+++ b/.bcr/supply_chain_tools/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
-  "strip_prefix": "{TAG}/metadata",
+  "strip_prefix": "{TAG}/tools",
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{TAG}.tar.gz"
 }


### PR DESCRIPTION
This should fix the publish to BCR phase of the release workflow.